### PR TITLE
Fix flyout reboot and shutdown action

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -128,6 +128,8 @@ html.sidebar-collapsed .footer-btn, body.sidebar-collapsed .footer-btn {
   border: 1px solid var(--color-border);
   border-radius: 12px;
   box-shadow: var(--shadow-lg);
+  position: relative;
+  z-index: 1;
   width: 50px;
   min-width: 50px;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- Ensure flyout panel sits above backdrop so reboot and shutdown actions work

## Testing
- `python manage.py test` *(fails: can't open file)*

------
https://chatgpt.com/codex/tasks/task_e_689b4358fdd88323a43a64a279755b79