### PR TITLE
Add projects page with sidebar editing

### DIFF
--- a/mavomaster/urls.py
+++ b/mavomaster/urls.py
@@ -24,6 +24,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', views.hompage),
     path('messung/', include('messung.urls')),
+    path('projekte/', messung.views.projekte_page, name='projekte_page'),
     path('system/reboot/', views.system_reboot, name='system_reboot'),
     path('system/shutdown/', views.system_shutdown, name='system_shutdown'),
 ]

--- a/messung/templates/messung/projekte_page.html
+++ b/messung/templates/messung/projekte_page.html
@@ -1,0 +1,32 @@
+{% extends "layout.html" %}
+{% block title %}Projekte – MavoMaster{% endblock %}
+{% block sidebar_context %}
+  <div class="card"><h3>Bearbeiten</h3><p>Wähle ein Projekt oder Objekt zum Bearbeiten.</p></div>
+{% endblock %}
+{% block content %}
+  <div id="projekt-list">
+    {% for projekt in projekte %}
+      <section class="card projekt-card" data-projekt-id="{{ projekt.id }}">
+        <h3>{{ projekt.name }}</h3>
+        <button class="edit-btn projekt-edit" data-projekt-id="{{ projekt.id }}" title="Projekt bearbeiten">
+          <span class="icon">{% include "icons/pencil-square.svg" %}</span>
+        </button>
+      </section>
+      <div class="objekte-container" data-projekt-id="{{ projekt.id }}" style="display:none;"></div>
+    {% empty %}
+      <section class="card"><p>Keine Projekte vorhanden.</p></section>
+    {% endfor %}
+  </div>
+
+  <template id="objekt-template">
+    <section class="card card-sub objekt-card" data-objekt-id="">
+      <h3 class="objekt-name"></h3>
+      <button class="edit-btn objekt-edit" data-objekt-id="" title="Objekt bearbeiten">
+        <span class="icon">{% include "icons/pencil-square.svg" %}</span>
+      </button>
+    </section>
+  </template>
+{% endblock %}
+{% block extra_js %}
+  <script src="{% static 'js/projekte.js' %}"></script>
+{% endblock %}

--- a/messung/views.py
+++ b/messung/views.py
@@ -33,6 +33,11 @@ def messung_page(request):
     return render(request, 'messung/messung_page.html', context)
 
 
+def projekte_page(request):
+    projekte = Projekt.objects.all().order_by('name')
+    return render(request, 'messung/projekte_page.html', {'projekte': projekte})
+
+
 def projekt_details(request, projekt_id):
     projekt = get_object_or_404(Projekt, pk=projekt_id)
     return JsonResponse({'id': projekt.id, 'name': projekt.name, 'code': projekt.code, 'beschreibung': projekt.beschreibung})

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -100,8 +100,12 @@ html.sidebar-collapsed .footer-btn, body.sidebar-collapsed .footer-btn {
 }
 
 /* Cards */
-.card { background: var(--color-surface); border:1px solid var(--color-border); border-radius:12px; padding:1rem; }
+.card { background: var(--color-surface); border:1px solid var(--color-border); border-radius:12px; padding:1rem; position:relative; }
 .card h2, .card h3 { color: var(--primary); margin:0 0 .75rem; }
+.card .edit-btn { position:absolute; top:.5rem; right:.5rem; background:transparent; border:none; width:28px; height:28px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; cursor:pointer; }
+.card .edit-btn:hover { background:#2c2c2c; }
+.card .edit-btn .icon, .card .edit-btn .icon svg { width:20px; height:20px; }
+.card.card-sub { margin-left:1rem; }
 
 /* Modal */
 .mm-btn { display:inline-flex; align-items:center; justify-content:center;
@@ -128,6 +132,8 @@ html.sidebar-collapsed .footer-btn, body.sidebar-collapsed .footer-btn {
   border: 1px solid var(--color-border);
   border-radius: 12px;
   box-shadow: var(--shadow-lg);
+  position: relative;
+  z-index: 1;
   width: 50px;
   min-width: 50px;
   overflow: hidden;

--- a/static/js/projekte.js
+++ b/static/js/projekte.js
@@ -1,0 +1,92 @@
+(function(){
+  function getCookie(name){
+    var value='; '+document.cookie;
+    var parts=value.split('; '+name+'=');
+    if(parts.length===2) return parts.pop().split(';').shift();
+  }
+  function openSidebar(){
+    document.documentElement.classList.remove('sidebar-collapsed');
+    document.body.classList.remove('sidebar-collapsed');
+    var toggle=document.getElementById('sidebar-toggle');
+    if(toggle) toggle.setAttribute('aria-expanded','true');
+    try{localStorage.setItem('mm.sidebar.collapsed','0');}catch(e){}
+  }
+  function escapeHtml(str){
+    var div=document.createElement('div');
+    div.textContent=str||'';
+    return div.innerHTML;
+  }
+  var sidebarContext=document.querySelector('.sidebar-context');
+  function openProjektEdit(id,card){
+    fetch('/messung/api/projekte/'+id+'/details/').then(r=>r.json()).then(function(data){
+      sidebarContext.innerHTML='<div class="card"><h3>Projekt bearbeiten</h3><form id="form-projekt">'+
+        '<label>Code<br><input name="code" value="'+escapeHtml(data.code)+'"></label><br>'+
+        '<label>Name<br><input name="name" value="'+escapeHtml(data.name)+'"></label><br>'+
+        '<label>Beschreibung<br><textarea name="beschreibung">'+escapeHtml(data.beschreibung||'')+'</textarea></label><br>'+
+        '<button type="submit" class="mm-btn mm-btn--primary">Speichern</button>'+
+      '</form></div>';
+      openSidebar();
+      var form=document.getElementById('form-projekt');
+      form.addEventListener('submit',function(e){
+        e.preventDefault();
+        var payload={code:this.code.value,name:this.name.value,beschreibung:this.beschreibung.value};
+        fetch('/messung/api/projekte/'+id+'/update/',{method:'PUT',headers:{'Content-Type':'application/json','X-CSRFToken':getCookie('csrftoken')},body:JSON.stringify(payload)})
+          .then(r=>r.json()).then(function(res){ if(!res.error){ card.querySelector('h3').textContent=res.name; } });
+      });
+    });
+  }
+  function openObjektEdit(id,card){
+    fetch('/messung/api/objekte/'+id+'/details/').then(r=>r.json()).then(function(data){
+      sidebarContext.innerHTML='<div class="card"><h3>Objekt bearbeiten</h3><form id="form-objekt">'+
+        '<label>Nummer<br><input name="nummer" value="'+escapeHtml(data.nummer)+'"></label><br>'+
+        '<label>Name<br><input name="name" value="'+escapeHtml(data.name)+'"></label><br>'+
+        '<button type="submit" class="mm-btn mm-btn--primary">Speichern</button>'+
+      '</form></div>';
+      openSidebar();
+      var form=document.getElementById('form-objekt');
+      form.addEventListener('submit',function(e){
+        e.preventDefault();
+        var payload={nummer:this.nummer.value,name:this.name.value};
+        fetch('/messung/api/objekte/'+id+'/update/',{method:'PUT',headers:{'Content-Type':'application/json','X-CSRFToken':getCookie('csrftoken')},body:JSON.stringify(payload)})
+          .then(r=>r.json()).then(function(res){ if(!res.error){ card.querySelector('h3').textContent=res.name; } });
+      });
+    });
+  }
+  function loadObjekte(card){
+    var pid=card.getAttribute('data-projekt-id');
+    var container=card.nextElementSibling;
+    if(container.getAttribute('data-loaded')==='1'){
+      container.style.display=container.style.display==='none'?'block':'none';
+      return;
+    }
+    fetch('/messung/api/projekte/'+pid+'/objekte/').then(r=>r.json()).then(function(list){
+      var tpl=document.getElementById('objekt-template');
+      container.innerHTML='';
+      list.forEach(function(o){
+        var node=tpl.content.firstElementChild.cloneNode(true);
+        node.setAttribute('data-objekt-id',o.id);
+        node.querySelector('.objekt-name').textContent=o.name;
+        var btn=node.querySelector('.objekt-edit');
+        btn.setAttribute('data-objekt-id',o.id);
+        btn.addEventListener('click',function(ev){ev.stopPropagation();openObjektEdit(o.id,node);});
+        container.appendChild(node);
+      });
+      container.setAttribute('data-loaded','1');
+      container.style.display='block';
+    });
+  }
+  document.querySelectorAll('.projekt-card').forEach(function(card){
+    card.addEventListener('click',function(e){
+      if(e.target.closest('.edit-btn')) return;
+      loadObjekte(card);
+    });
+  });
+  document.querySelectorAll('.projekt-edit').forEach(function(btn){
+    btn.addEventListener('click',function(e){
+      e.stopPropagation();
+      var card=e.target.closest('.projekt-card');
+      openProjektEdit(btn.getAttribute('data-projekt-id'),card);
+    });
+  });
+})();
+


### PR DESCRIPTION
## Summary
- Create projects page listing projects and objects with sidebar edit forms
- Style cards with edit buttons and indentation for project objects

## Testing
- `python manage.py test` *(fails: can't open file '/workspace/mavomasterpi/manage.py')*

------
https://chatgpt.com/codex/tasks/task_e_689b4358fdd88323a43a64a279755b79