### PR TITLE
Implement three-column project view with contextual sidebar

### DIFF
--- a/messung/templates/messung/messung_edit.html
+++ b/messung/templates/messung/messung_edit.html
@@ -1,4 +1,4 @@
 <div class="card">
   <h3>Messung</h3>
-  <p>Kontextabhängige Optionen für Messungen.</p>
+  <p>{{ selected_messung.name }}</p>
 </div>

--- a/messung/templates/messung/objekt_edit.html
+++ b/messung/templates/messung/objekt_edit.html
@@ -1,4 +1,9 @@
 <div class="card">
   <h3>Objekt</h3>
-  <p>Kontextabhängige Optionen für Objekte.</p>
+  <p>
+    <a href="{% url 'objekt_edit' selected_objekt.id %}" class="mm-btn">
+      <span class="icon">{% include "icons/pencil-square.svg" %}</span>
+      <span class="label">Objekt bearbeiten</span>
+    </a>
+  </p>
 </div>

--- a/messung/templates/messung/objekt_form.html
+++ b/messung/templates/messung/objekt_form.html
@@ -1,10 +1,15 @@
 {% extends "layout.html" %}
 {% block title %}{% if form.instance.pk %}Objekt bearbeiten{% else %}Objekt anlegen{% endif %} – MavoMaster{% endblock %}
 {% block content %}
-  <h2>{% if form.instance.pk %}Objekt bearbeiten{% else %}Neues Objekt{% endif %}</h2>
-  <form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="mm-btn mm-btn--primary">Speichern</button>
-  </form>
+  <section class="card">
+    <h2>{% if form.instance.pk %}Objekt bearbeiten{% else %}Neues Objekt{% endif %}</h2>
+    <form method="post">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <button type="submit" class="mm-btn mm-btn--primary">
+        <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
+        <span class="label">Speichern</span>
+      </button>
+    </form>
+  </section>
 {% endblock %}

--- a/messung/templates/messung/projek_edit.html
+++ b/messung/templates/messung/projek_edit.html
@@ -1,13 +1,13 @@
 <div class="card">
-  <h3>Aktionen</h3>
+  <h3>Projekt</h3>
   <p>
-    <a href="{% url 'projekt_add' %}" class="mm-btn">
-      <span class="icon">{% include "icons/folder-plus.svg" %}</span>
-      <span class="label">Projekt hinzufügen</span>
+    <a href="{% url 'projekt_edit' selected_projekt.id %}" class="mm-btn">
+      <span class="icon">{% include "icons/pencil-square.svg" %}</span>
+      <span class="label">Projekt bearbeiten</span>
     </a>
   </p>
   <p>
-    <a href="{% url 'objekt_add' %}" class="mm-btn">
+    <a href="{% url 'objekt_add_project' selected_projekt.id %}" class="mm-btn">
       <span class="icon">{% include "icons/document-plus.svg" %}</span>
       <span class="label">Objekt hinzufügen</span>
     </a>

--- a/messung/templates/messung/projekt_form.html
+++ b/messung/templates/messung/projekt_form.html
@@ -1,10 +1,15 @@
 {% extends "layout.html" %}
 {% block title %}{% if form.instance.pk %}Projekt bearbeiten{% else %}Projekt anlegen{% endif %} – MavoMaster{% endblock %}
 {% block content %}
-  <h2>{% if form.instance.pk %}Projekt bearbeiten{% else %}Neues Projekt{% endif %}</h2>
-  <form method="post">
-    {% csrf_token %}
-    {{ form.as_p }}
-    <button type="submit" class="mm-btn mm-btn--primary">Speichern</button>
-  </form>
+  <section class="card">
+    <h2>{% if form.instance.pk %}Projekt bearbeiten{% else %}Neues Projekt{% endif %}</h2>
+    <form method="post">
+      {% csrf_token %}
+      {{ form.as_p }}
+      <button type="submit" class="mm-btn mm-btn--primary">
+        <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
+        <span class="label">Speichern</span>
+      </button>
+    </form>
+  </section>
 {% endblock %}

--- a/messung/templates/messung/projekte_page.html
+++ b/messung/templates/messung/projekte_page.html
@@ -1,44 +1,67 @@
 {% extends "layout.html" %}
 {% block title %}Projekte – MavoMaster{% endblock %}
 {% block sidebar_context %}
-  {% include "messung/projek_edit.html" %}
+  <p class="always-visible">
+    <a href="{% url 'projekt_add' %}" class="mm-btn" title="Projekt hinzufügen">
+      <span class="icon">{% include "icons/folder-plus.svg" %}</span>
+      <span class="label">Projekt hinzufügen</span>
+    </a>
+  </p>
+  {% if selected_messung %}
+    {% include "messung/messung_edit.html" %}
+  {% elif selected_objekt %}
+    {% include "messung/objekt_edit.html" %}
+  {% elif selected_projekt %}
+    {% include "messung/projek_edit.html" %}
+  {% endif %}
 {% endblock %}
 {% block content %}
-  <div id="projekt-list">
-    {% for projekt in projekte %}
-      <div class="projekt-block">
-        <section class="card projekt-card has-delete">
-          <h3>{{ projekt.code }} {{ projekt.name }}</h3>
-          <a href="{% url 'projekt_edit' projekt.id %}" class="edit-btn" title="Projekt bearbeiten">
-            <span class="icon">{% include "icons/pencil-square.svg" %}</span>
-          </a>
-          <form method="post" action="{% url 'projekt_delete' projekt.id %}">
-            {% csrf_token %}
-            <button type="submit" class="delete-btn" title="Projekt löschen">
-              <span class="icon">{% include "icons/trash.svg" %}</span>
-            </button>
-          </form>
-        </section>
-        {% for objekt in projekt.objekte.all %}
-          <section class="card card-sub objekt-card has-delete">
-            <h4>{{ objekt.name }}</h4>
-            <a href="{% url 'objekt_edit' objekt.id %}" class="edit-btn" title="Objekt bearbeiten">
-              <span class="icon">{% include "icons/pencil-square.svg" %}</span>
-            </a>
-            <form method="post" action="{% url 'objekt_delete' objekt.id %}">
-              {% csrf_token %}
-              <button type="submit" class="delete-btn" title="Objekt löschen">
-                <span class="icon">{% include "icons/trash.svg" %}</span>
-              </button>
-            </form>
+  <div class="projekt-columns">
+    <div class="column">
+      {% for projekt in projekte %}
+        <a href="{% url 'projekte_page' %}?projekt={{ projekt.id }}">
+          <section class="card projekt-card{% if selected_projekt and projekt.id == selected_projekt.id %} selected{% endif %}">
+            <h3>{{ projekt.code }} {{ projekt.name }}</h3>
           </section>
+        </a>
+      {% empty %}
+        <section class="card"><p>Keine Projekte vorhanden.</p></section>
+      {% endfor %}
+    </div>
+    <div class="column">
+      {% if selected_projekt %}
+        {% for objekt in objekte %}
+          <a href="{% url 'projekte_page' %}?projekt={{ selected_projekt.id }}&objekt={{ objekt.id }}">
+            <section class="card objekt-card{% if selected_objekt and objekt.id == selected_objekt.id %} selected{% endif %}">
+              <h4>{{ objekt.name }}</h4>
+            </section>
+          </a>
         {% empty %}
-          <section class="card card-sub"><p>Keine Objekte vorhanden.</p></section>
+          <section class="card"><p>Keine Objekte vorhanden.</p></section>
         {% endfor %}
-      </div>
-    {% empty %}
-      <section class="card"><p>Keine Projekte vorhanden.</p></section>
-    {% endfor %}
-    <section class="card"><a href="{% url 'projekt_add' %}" class="mm-btn">Projekt hinzufügen</a></section>
+      {% endif %}
+    </div>
+    <div class="column">
+      {% if selected_objekt %}
+        {% for messung in messungen %}
+          <a href="{% url 'projekte_page' %}?projekt={{ selected_projekt.id }}&objekt={{ selected_objekt.id }}&messung={{ messung.id }}">
+            <section class="card{% if selected_messung and messung.id == selected_messung.id %} selected{% endif %}">
+              <h4>{{ messung.name }}</h4>
+            </section>
+          </a>
+        {% empty %}
+          <section class="card"><p>Keine Messungen vorhanden.</p></section>
+        {% endfor %}
+      {% endif %}
+    </div>
   </div>
+{% endblock %}
+{% block extra_js %}
+{% if selected_projekt or selected_objekt or selected_messung %}
+<script>
+  document.documentElement.classList.remove('sidebar-collapsed');
+  document.body.classList.remove('sidebar-collapsed');
+  try { localStorage.setItem('mm.sidebar.collapsed','0'); } catch(e){}
+</script>
+{% endif %}
 {% endblock %}

--- a/messung/views.py
+++ b/messung/views.py
@@ -37,7 +37,34 @@ def messung_page(request):
 
 def projekte_page(request):
     projekte = Projekt.objects.all().order_by('name')
-    return render(request, 'messung/projekte_page.html', {'projekte': projekte})
+    projekt_id = request.GET.get('projekt')
+    objekt_id = request.GET.get('objekt')
+    messung_id = request.GET.get('messung')
+
+    selected_projekt = None
+    selected_objekt = None
+    selected_messung = None
+    objekte = []
+    messungen = []
+
+    if projekt_id:
+        selected_projekt = get_object_or_404(Projekt, pk=projekt_id)
+        objekte = selected_projekt.objekte.all().order_by('name')
+        if objekt_id:
+            selected_objekt = get_object_or_404(Objekt, pk=objekt_id, projekt=selected_projekt)
+            messungen = selected_objekt.messungen.all().order_by('-erstellt_am')
+            if messung_id:
+                selected_messung = get_object_or_404(Messdaten, pk=messung_id, objekt=selected_objekt)
+
+    context = {
+        'projekte': projekte,
+        'selected_projekt': selected_projekt,
+        'objekte': objekte,
+        'selected_objekt': selected_objekt,
+        'messungen': messungen,
+        'selected_messung': selected_messung,
+    }
+    return render(request, 'messung/projekte_page.html', context)
 
 
 def projekt_add(request):

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -28,7 +28,7 @@
   --primary: var(--primary-700);
   --secondary: var(--secondary-500);
   --svg-icon: var(--primary);
-  --sidebar-open-w: min(900px, 100vw);
+  --sidebar-open-w: min(600px, 100vw);
   --sidebar-collapsed-w: 50px;
   --shadow-lg: 0 20px 50px rgba(0,0,0,.4);
 }
@@ -110,7 +110,8 @@ a { color: inherit; text-decoration: none; }
 html.sidebar-collapsed #app-sidebar, body.sidebar-collapsed #app-sidebar { width: var(--sidebar-collapsed-w); }
 html.sidebar-collapsed #main-content, body.sidebar-collapsed #main-content { margin-left: var(--sidebar-collapsed-w); }
 html.sidebar-collapsed .label, body.sidebar-collapsed .label,
-html.sidebar-collapsed .sidebar-context > *, body.sidebar-collapsed .sidebar-context > * { display:none !important; }
+html.sidebar-collapsed .sidebar-context > *:not(.always-visible), body.sidebar-collapsed .sidebar-context > *:not(.always-visible) { display:none !important; }
+html.sidebar-collapsed .sidebar-context .mm-btn, body.sidebar-collapsed .sidebar-context .mm-btn { min-width:auto; }
 html.sidebar-collapsed #sidebar-toggle .open, body.sidebar-collapsed #sidebar-toggle .open { display:none; }
 html.sidebar-collapsed #sidebar-toggle .closed, body.sidebar-collapsed #sidebar-toggle .closed { display:inline-flex; }
 #sidebar-toggle .closed { display:none; }
@@ -137,6 +138,22 @@ html.sidebar-collapsed .footer-btn, body.sidebar-collapsed .footer-btn {
 .projekt-card { margin-bottom:10px; height: 50px;}
 .objekt-card { margin-bottom:10px; margin-top:10px; height: 50px;}
 .objekt-card h4 { color: var(--secondary); margin-block-start: 0px; margin-block-end: 0px;}
+
+.card.selected { border-color: var(--primary); }
+
+.projekt-columns { display:grid; grid-template-columns:repeat(3,1fr); gap:1rem; }
+.projekt-columns .column { overflow:auto; max-height:80vh; }
+
+input, textarea, select {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  border-radius: 8px;
+  padding: .4rem;
+  width: 100%;
+}
+
+form p { margin:0 0 1rem; }
 
 /* Modal */
 .mm-btn { display:inline-flex; align-items:center; justify-content:center;


### PR DESCRIPTION
## Summary
- Constrain sidebar to 600px when open and allow always-visible project add action
- Add three-column project page showing projects, objects, and measurements with contextual sidebar forms
- Style edit forms and save buttons to match app theme

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689b879171408323ad915054fcbea06d