### PR TITLE
Rework project sidebar hierarchy

### DIFF
--- a/mavomaster/urls.py
+++ b/mavomaster/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     path('projekte/<int:projekt_id>/objekt/add/', messung.views.objekt_add, name='objekt_add_project'),
     path('objekte/<int:objekt_id>/edit/', messung.views.objekt_edit, name='objekt_edit'),
     path('objekte/<int:objekt_id>/delete/', messung.views.objekt_delete, name='objekt_delete'),
+    path('messungen/<int:messung_id>/edit/', messung.views.messung_edit, name='messung_edit'),
     path('system/reboot/', views.system_reboot, name='system_reboot'),
     path('system/shutdown/', views.system_shutdown, name='system_shutdown'),
 ]

--- a/messung/forms.py
+++ b/messung/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from .models import Projekt, Objekt
+from .models import Projekt, Objekt, Messdaten
 
 
 class ProjektForm(forms.ModelForm):
@@ -12,3 +12,9 @@ class ObjektForm(forms.ModelForm):
     class Meta:
         model = Objekt
         fields = ['projekt', 'nummer', 'name']
+
+
+class MessungForm(forms.ModelForm):
+    class Meta:
+        model = Messdaten
+        fields = ['anforderung', 'messbedingungen', 'messhoehe']

--- a/messung/templates/messung/messung_edit.html
+++ b/messung/templates/messung/messung_edit.html
@@ -1,4 +1,17 @@
-<div class="card">
-  <h3>Messung</h3>
-  <p>{{ selected_messung.name }}</p>
-</div>
+<h3>Messung</h3>
+<form method="post" action="{% url 'messung_edit' selected_messung.id %}">
+  {% csrf_token %}
+  <div class="form-row">
+    {{ messung_form.anforderung.label_tag }} {{ messung_form.anforderung }}
+  </div>
+  <div class="form-row">
+    {{ messung_form.messbedingungen.label_tag }} {{ messung_form.messbedingungen }}
+  </div>
+  <div class="form-row">
+    {{ messung_form.messhoehe.label_tag }} {{ messung_form.messhoehe }}
+  </div>
+  <button type="submit" class="mm-btn mm-btn--primary">
+    <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
+    <span class="label">Speichern</span>
+  </button>
+</form>

--- a/messung/templates/messung/messung_form.html
+++ b/messung/templates/messung/messung_form.html
@@ -1,0 +1,23 @@
+{% extends "layout.html" %}
+{% block title %}Messung bearbeiten – MavoMaster{% endblock %}
+{% block content %}
+  <section class="card">
+    <h2>Messung bearbeiten</h2>
+    <form method="post">
+      {% csrf_token %}
+      <div class="form-row">
+        {{ form.anforderung.label_tag }} {{ form.anforderung }}
+      </div>
+      <div class="form-row">
+        {{ form.messbedingungen.label_tag }} {{ form.messbedingungen }}
+      </div>
+      <div class="form-row">
+        {{ form.messhoehe.label_tag }} {{ form.messhoehe }}
+      </div>
+      <button type="submit" class="mm-btn mm-btn--primary">
+        <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
+        <span class="label">Speichern</span>
+      </button>
+    </form>
+  </section>
+{% endblock %}

--- a/messung/templates/messung/objekt_edit.html
+++ b/messung/templates/messung/objekt_edit.html
@@ -1,9 +1,15 @@
-<div class="card">
-  <h3>Objekt</h3>
-  <p>
-    <a href="{% url 'objekt_edit' selected_objekt.id %}" class="mm-btn">
-      <span class="icon">{% include "icons/pencil-square.svg" %}</span>
-      <span class="label">Objekt bearbeiten</span>
-    </a>
-  </p>
-</div>
+<h3>Objekt</h3>
+<form method="post" action="{% url 'objekt_edit' selected_objekt.id %}">
+  {% csrf_token %}
+  {{ objekt_form.projekt }}
+  <div class="form-row">
+    {{ objekt_form.nummer.label_tag }} {{ objekt_form.nummer }}
+  </div>
+  <div class="form-row">
+    {{ objekt_form.name.label_tag }} {{ objekt_form.name }}
+  </div>
+  <button type="submit" class="mm-btn mm-btn--primary">
+    <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
+    <span class="label">Speichern</span>
+  </button>
+</form>

--- a/messung/templates/messung/projek_edit.html
+++ b/messung/templates/messung/projek_edit.html
@@ -1,15 +1,17 @@
-<div class="card">
-  <h3>Projekt</h3>
-  <p>
-    <a href="{% url 'projekt_edit' selected_projekt.id %}" class="mm-btn">
-      <span class="icon">{% include "icons/pencil-square.svg" %}</span>
-      <span class="label">Projekt bearbeiten</span>
-    </a>
-  </p>
-  <p>
-    <a href="{% url 'objekt_add_project' selected_projekt.id %}" class="mm-btn">
-      <span class="icon">{% include "icons/document-plus.svg" %}</span>
-      <span class="label">Objekt hinzufügen</span>
-    </a>
-  </p>
-</div>
+<h3>Projekt</h3>
+<form method="post" action="{% url 'projekt_edit' selected_projekt.id %}">
+  {% csrf_token %}
+  <div class="form-row">
+    {{ projekt_form.code.label_tag }} {{ projekt_form.code }}
+  </div>
+  <div class="form-row">
+    {{ projekt_form.name.label_tag }} {{ projekt_form.name }}
+  </div>
+  <div class="form-row">
+    {{ projekt_form.beschreibung.label_tag }} {{ projekt_form.beschreibung }}
+  </div>
+  <button type="submit" class="mm-btn mm-btn--primary">
+    <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
+    <span class="label">Speichern</span>
+  </button>
+</form>

--- a/messung/templates/messung/projekte_page.html
+++ b/messung/templates/messung/projekte_page.html
@@ -1,18 +1,29 @@
 {% extends "layout.html" %}
 {% block title %}Projekte – MavoMaster{% endblock %}
 {% block sidebar_context %}
-  <p class="always-visible">
-    <a href="{% url 'projekt_add' %}" class="mm-btn" title="Projekt hinzufügen">
-      <span class="icon">{% include "icons/folder-plus.svg" %}</span>
-      <span class="label">Projekt hinzufügen</span>
+  <nav class="sidebar-nav always-visible">
+    <a href="{% url 'projekt_add' %}" class="nav-item" title="Projekt hinzufügen">
+      <span class="icon">{% include "icons/folder-plus.svg" %}</span><span class="label">Projekt hinzufügen</span>
     </a>
-  </p>
+    {% if selected_projekt %}
+      <a href="{% url 'objekt_add_project' selected_projekt.id %}" class="nav-item" title="Objekt hinzufügen">
+        <span class="icon">{% include "icons/document-plus.svg" %}</span><span class="label">Objekt hinzufügen</span>
+      </a>
+    {% endif %}
+    {% if selected_objekt %}
+      <a href="{% url 'messung:page' %}?objekt={{ selected_objekt.id }}" class="nav-item" title="Messung hinzufügen">
+        <span class="icon">{% include "icons/document-plus.svg" %}</span><span class="label">Messung hinzufügen</span>
+      </a>
+    {% endif %}
+  </nav>
+  {% if selected_projekt %}
+    {% include "messung/projek_edit.html" %}
+  {% endif %}
+  {% if selected_objekt %}
+    {% include "messung/objekt_edit.html" %}
+  {% endif %}
   {% if selected_messung %}
     {% include "messung/messung_edit.html" %}
-  {% elif selected_objekt %}
-    {% include "messung/objekt_edit.html" %}
-  {% elif selected_projekt %}
-    {% include "messung/projek_edit.html" %}
   {% endif %}
 {% endblock %}
 {% block content %}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -86,6 +86,7 @@ a { color: inherit; text-decoration: none; }
 #sidebar-toggle svg { width:20px; height:20px; display:block; stroke:var(--svg-icon); }
 
 .sidebar-nav { display:flex; flex-direction:column; padding:.5rem; gap:.25rem; border-bottom:1px solid var(--color-border); overflow: hidden auto; }
+.sidebar-context .sidebar-nav { margin:0 -.6rem; border-bottom:none; }
 .nav-item { display:flex; align-items:center; gap:.6rem; padding:.45rem .6rem; border-radius:10px; min-height:36px; }
 .nav-item:hover { background:#2c2c2c; }
 .icon { display:inline-flex; width:20px; height:20px; align-items:center; justify-content:center; }
@@ -154,6 +155,8 @@ input, textarea, select {
 }
 
 form p { margin:0 0 1rem; }
+
+.form-row { display:grid; grid-template-columns:max-content 1fr; align-items:center; gap:.5rem; margin:0 0 1rem; }
 
 /* Modal */
 .mm-btn { display:inline-flex; align-items:center; justify-content:center;


### PR DESCRIPTION
## Summary
- Render project, object and measurement edit forms inline as single-row fields
- Enable editing of measurement requirements, conditions and height via new `MessungForm`
- Align sidebar action buttons with main navigation and remove form borders

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689b91bd4f6c8323bc4921e355e54093