### PR TITLE
Rework project sidebar hierarchy

### DIFF
--- a/mavomaster/urls.py
+++ b/mavomaster/urls.py
@@ -32,6 +32,8 @@ urlpatterns = [
     path('projekte/<int:projekt_id>/objekt/add/', messung.views.objekt_add, name='objekt_add_project'),
     path('objekte/<int:objekt_id>/edit/', messung.views.objekt_edit, name='objekt_edit'),
     path('objekte/<int:objekt_id>/delete/', messung.views.objekt_delete, name='objekt_delete'),
+    path('messungen/<int:messung_id>/edit/', messung.views.messung_edit, name='messung_edit'),
+    path('messungen/<int:messung_id>/delete/', messung.views.messung_delete, name='messung_delete'),
     path('system/reboot/', views.system_reboot, name='system_reboot'),
     path('system/shutdown/', views.system_shutdown, name='system_shutdown'),
 ]

--- a/messung/forms.py
+++ b/messung/forms.py
@@ -1,14 +1,23 @@
 from django import forms
-from .models import Projekt, Objekt
+from .models import Projekt, Objekt, Messdaten
 
 
 class ProjektForm(forms.ModelForm):
     class Meta:
         model = Projekt
         fields = ['code', 'name', 'beschreibung']
+        widgets = {
+            'beschreibung': forms.Textarea(attrs={'rows': 1})
+        }
 
 
 class ObjektForm(forms.ModelForm):
     class Meta:
         model = Objekt
         fields = ['projekt', 'nummer', 'name']
+
+
+class MessungForm(forms.ModelForm):
+    class Meta:
+        model = Messdaten
+        fields = ['anforderung', 'messbedingungen', 'messhoehe']

--- a/messung/templates/messung/messung_confirm_delete.html
+++ b/messung/templates/messung/messung_confirm_delete.html
@@ -1,0 +1,14 @@
+{% extends "layout.html" %}
+{% block title %}Messung löschen – MavoMaster{% endblock %}
+{% block content %}
+  <h2>Messung löschen</h2>
+  <p>Möchten Sie die Messung "{{ messung }}" wirklich löschen?</p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" class="mm-btn mm-btn--danger">
+      <span class="icon">{% include "icons/trash.svg" %}</span>
+      Löschen
+    </button>
+    <a href="{% url 'projekte_page' %}" class="mm-btn">Abbrechen</a>
+  </form>
+{% endblock %}

--- a/messung/templates/messung/messung_edit.html
+++ b/messung/templates/messung/messung_edit.html
@@ -1,4 +1,25 @@
-<div class="card">
-  <h3>Messung</h3>
-  <p>{{ selected_messung.name }}</p>
-</div>
+<form method="post" action="{% url 'messung_edit' selected_messung.id %}" class="edit-form" id="messung-edit-form">
+  {% csrf_token %}
+  <div class="form-header">
+    <span class="form-title">Messung</span>
+    <div class="form-actions">
+      <button type="submit" class="icon-btn" title="Speichern">
+        <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
+      </button>
+      <button type="button" class="icon-btn accordion-toggle" data-target="#messung-fields" title="Minimieren">
+        <span class="icon">{% include "icons/chevron-up.svg" %}</span>
+      </button>
+    </div>
+  </div>
+  <div id="messung-fields" class="accordion-body">
+    <div class="form-row">
+      {{ messung_form.anforderung.label_tag }} {{ messung_form.anforderung }}
+    </div>
+    <div class="form-row">
+      {{ messung_form.messbedingungen.label_tag }} {{ messung_form.messbedingungen }}
+    </div>
+    <div class="form-row">
+      {{ messung_form.messhoehe.label_tag }} {{ messung_form.messhoehe }}
+    </div>
+  </div>
+</form>

--- a/messung/templates/messung/messung_form.html
+++ b/messung/templates/messung/messung_form.html
@@ -1,0 +1,22 @@
+{% extends "layout.html" %}
+{% block title %}Messung bearbeiten – MavoMaster{% endblock %}
+{% block content %}
+  <section class="card">
+    <h2>Messung bearbeiten</h2>
+    <form method="post">
+      {% csrf_token %}
+      <div class="form-row">
+        {{ form.anforderung.label_tag }} {{ form.anforderung }}
+      </div>
+      <div class="form-row">
+        {{ form.messbedingungen.label_tag }} {{ form.messbedingungen }}
+      </div>
+      <div class="form-row">
+        {{ form.messhoehe.label_tag }} {{ form.messhoehe }}
+      </div>
+      <button type="submit" class="icon-btn" title="Speichern">
+        <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
+      </button>
+    </form>
+  </section>
+{% endblock %}

--- a/messung/templates/messung/objekt_edit.html
+++ b/messung/templates/messung/objekt_edit.html
@@ -1,9 +1,23 @@
-<div class="card">
-  <h3>Objekt</h3>
-  <p>
-    <a href="{% url 'objekt_edit' selected_objekt.id %}" class="mm-btn">
-      <span class="icon">{% include "icons/pencil-square.svg" %}</span>
-      <span class="label">Objekt bearbeiten</span>
-    </a>
-  </p>
-</div>
+<form method="post" action="{% url 'objekt_edit' selected_objekt.id %}" class="edit-form" id="objekt-edit-form">
+  {% csrf_token %}
+  {{ objekt_form.projekt }}
+  <div class="form-header">
+    <span class="form-title">Objekt</span>
+    <div class="form-actions">
+      <button type="submit" class="icon-btn" title="Speichern">
+        <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
+      </button>
+      <button type="button" class="icon-btn accordion-toggle" data-target="#objekt-fields" title="Minimieren">
+        <span class="icon">{% include "icons/chevron-up.svg" %}</span>
+      </button>
+    </div>
+  </div>
+  <div id="objekt-fields" class="accordion-body">
+    <div class="form-row">
+      {{ objekt_form.nummer.label_tag }} {{ objekt_form.nummer }}
+    </div>
+    <div class="form-row">
+      {{ objekt_form.name.label_tag }} {{ objekt_form.name }}
+    </div>
+  </div>
+</form>

--- a/messung/templates/messung/objekt_form.html
+++ b/messung/templates/messung/objekt_form.html
@@ -6,9 +6,8 @@
     <form method="post">
       {% csrf_token %}
       {{ form.as_p }}
-      <button type="submit" class="mm-btn mm-btn--primary">
+      <button type="submit" class="icon-btn" title="Speichern">
         <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
-        <span class="label">Speichern</span>
       </button>
     </form>
   </section>

--- a/messung/templates/messung/projek_edit.html
+++ b/messung/templates/messung/projek_edit.html
@@ -1,15 +1,25 @@
-<div class="card">
-  <h3>Projekt</h3>
-  <p>
-    <a href="{% url 'projekt_edit' selected_projekt.id %}" class="mm-btn">
-      <span class="icon">{% include "icons/pencil-square.svg" %}</span>
-      <span class="label">Projekt bearbeiten</span>
-    </a>
-  </p>
-  <p>
-    <a href="{% url 'objekt_add_project' selected_projekt.id %}" class="mm-btn">
-      <span class="icon">{% include "icons/document-plus.svg" %}</span>
-      <span class="label">Objekt hinzufügen</span>
-    </a>
-  </p>
-</div>
+<form method="post" action="{% url 'projekt_edit' selected_projekt.id %}" class="edit-form" id="projekt-edit-form">
+  {% csrf_token %}
+  <div class="form-header">
+    <span class="form-title">Projekt</span>
+    <div class="form-actions">
+      <button type="submit" class="icon-btn" title="Speichern">
+        <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
+      </button>
+      <button type="button" class="icon-btn accordion-toggle" data-target="#projekt-fields" title="Minimieren">
+        <span class="icon">{% include "icons/chevron-up.svg" %}</span>
+      </button>
+    </div>
+  </div>
+  <div id="projekt-fields" class="accordion-body">
+    <div class="form-row">
+      {{ projekt_form.code.label_tag }} {{ projekt_form.code }}
+    </div>
+    <div class="form-row">
+      {{ projekt_form.name.label_tag }} {{ projekt_form.name }}
+    </div>
+    <div class="form-row">
+      {{ projekt_form.beschreibung.label_tag }} {{ projekt_form.beschreibung }}
+    </div>
+  </div>
+</form>

--- a/messung/templates/messung/projekt_form.html
+++ b/messung/templates/messung/projekt_form.html
@@ -6,9 +6,8 @@
     <form method="post">
       {% csrf_token %}
       {{ form.as_p }}
-      <button type="submit" class="mm-btn mm-btn--primary">
+      <button type="submit" class="icon-btn" title="Speichern">
         <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
-        <span class="label">Speichern</span>
       </button>
     </form>
   </section>

--- a/messung/templates/messung/projekte_page.html
+++ b/messung/templates/messung/projekte_page.html
@@ -1,29 +1,46 @@
 {% extends "layout.html" %}
 {% block title %}Projekte – MavoMaster{% endblock %}
 {% block sidebar_context %}
-  <p class="always-visible">
-    <a href="{% url 'projekt_add' %}" class="mm-btn" title="Projekt hinzufügen">
-      <span class="icon">{% include "icons/folder-plus.svg" %}</span>
-      <span class="label">Projekt hinzufügen</span>
+  <nav class="sidebar-nav always-visible">
+    <a href="{% url 'projekt_add' %}" class="nav-item" title="Projekt hinzufügen">
+      <span class="icon">{% include "icons/folder-plus.svg" %}</span><span class="label">Projekt hinzufügen</span>
     </a>
-  </p>
+    {% if selected_projekt %}
+      <a href="{% url 'objekt_add_project' selected_projekt.id %}" class="nav-item" title="Objekt hinzufügen">
+        <span class="icon">{% include "icons/document-plus.svg" %}</span><span class="label">Objekt hinzufügen</span>
+      </a>
+    {% endif %}
+    {% if selected_objekt %}
+      <a href="{% url 'messung:page' %}?objekt={{ selected_objekt.id }}" class="nav-item" title="Messung hinzufügen">
+        <span class="icon">{% include "icons/document-plus.svg" %}</span><span class="label">Messung hinzufügen</span>
+      </a>
+    {% endif %}
+  </nav>
+  {% if selected_projekt %}
+    {% include "messung/projek_edit.html" %}
+  {% endif %}
+  {% if selected_objekt %}
+    {% include "messung/objekt_edit.html" %}
+  {% endif %}
   {% if selected_messung %}
     {% include "messung/messung_edit.html" %}
-  {% elif selected_objekt %}
-    {% include "messung/objekt_edit.html" %}
-  {% elif selected_projekt %}
-    {% include "messung/projek_edit.html" %}
   {% endif %}
 {% endblock %}
 {% block content %}
   <div class="projekt-columns">
     <div class="column">
       {% for projekt in projekte %}
-        <a href="{% url 'projekte_page' %}?projekt={{ projekt.id }}">
-          <section class="card projekt-card{% if selected_projekt and projekt.id == selected_projekt.id %} selected{% endif %}">
+        <section class="card projekt-card has-delete{% if selected_projekt and projekt.id == selected_projekt.id %} selected{% endif %}">
+          <a href="{% url 'projekte_page' %}?projekt={{ projekt.id }}">
             <h3>{{ projekt.code }} {{ projekt.name }}</h3>
-          </section>
-        </a>
+          </a>
+          <form method="post" action="{% url 'projekt_delete' projekt.id %}" onsubmit="return confirm('Möchten Sie wirklich löschen?');">
+            {% csrf_token %}
+            <button type="submit" class="delete-btn" title="Löschen">
+              <span class="icon">{% include "icons/trash.svg" %}</span>
+            </button>
+          </form>
+        </section>
       {% empty %}
         <section class="card"><p>Keine Projekte vorhanden.</p></section>
       {% endfor %}
@@ -31,11 +48,17 @@
     <div class="column">
       {% if selected_projekt %}
         {% for objekt in objekte %}
-          <a href="{% url 'projekte_page' %}?projekt={{ selected_projekt.id }}&objekt={{ objekt.id }}">
-            <section class="card objekt-card{% if selected_objekt and objekt.id == selected_objekt.id %} selected{% endif %}">
+          <section class="card objekt-card has-delete{% if selected_objekt and objekt.id == selected_objekt.id %} selected{% endif %}">
+            <a href="{% url 'projekte_page' %}?projekt={{ selected_projekt.id }}&objekt={{ objekt.id }}">
               <h4>{{ objekt.name }}</h4>
-            </section>
-          </a>
+            </a>
+            <form method="post" action="{% url 'objekt_delete' objekt.id %}" onsubmit="return confirm('Möchten Sie wirklich löschen?');">
+              {% csrf_token %}
+              <button type="submit" class="delete-btn" title="Löschen">
+                <span class="icon">{% include "icons/trash.svg" %}</span>
+              </button>
+            </form>
+          </section>
         {% empty %}
           <section class="card"><p>Keine Objekte vorhanden.</p></section>
         {% endfor %}
@@ -44,11 +67,17 @@
     <div class="column">
       {% if selected_objekt %}
         {% for messung in messungen %}
-          <a href="{% url 'projekte_page' %}?projekt={{ selected_projekt.id }}&objekt={{ selected_objekt.id }}&messung={{ messung.id }}">
-            <section class="card{% if selected_messung and messung.id == selected_messung.id %} selected{% endif %}">
+          <section class="card has-delete{% if selected_messung and messung.id == selected_messung.id %} selected{% endif %}">
+            <a href="{% url 'projekte_page' %}?projekt={{ selected_projekt.id }}&objekt={{ selected_objekt.id }}&messung={{ messung.id }}">
               <h4>{{ messung.name }}</h4>
-            </section>
-          </a>
+            </a>
+            <form method="post" action="{% url 'messung_delete' messung.id %}" onsubmit="return confirm('Möchten Sie wirklich löschen?');">
+              {% csrf_token %}
+              <button type="submit" class="delete-btn" title="Löschen">
+                <span class="icon">{% include "icons/trash.svg" %}</span>
+              </button>
+            </form>
+          </section>
         {% empty %}
           <section class="card"><p>Keine Messungen vorhanden.</p></section>
         {% endfor %}
@@ -64,4 +93,13 @@
   try { localStorage.setItem('mm.sidebar.collapsed','0'); } catch(e){}
 </script>
 {% endif %}
+<script>
+  document.querySelectorAll('.accordion-toggle').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = document.querySelector(btn.dataset.target);
+      target.classList.toggle('collapsed');
+      btn.classList.toggle('collapsed');
+    });
+  });
+</script>
 {% endblock %}

--- a/messung/views.py
+++ b/messung/views.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, get_object_or_404, redirect
 from django.http import JsonResponse, HttpResponse
+from django.urls import reverse
 from django import forms
 from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
@@ -12,7 +13,7 @@ from openpyxl import Workbook
 from openpyxl.styles import Font, Alignment
 
 from .models import Projekt, Objekt, Messdaten, Anforderungen
-from .forms import ProjektForm, ObjektForm
+from .forms import ProjektForm, ObjektForm, MessungForm
 from .logic import (
     MeasurementThread, MavoMasterDevice, RealtimePollingThread,
     MEASUREMENT_THREAD, DEVICE, POLLING_THREAD
@@ -46,23 +47,34 @@ def projekte_page(request):
     selected_messung = None
     objekte = []
     messungen = []
+    projekt_form = None
+    objekt_form = None
+    messung_form = None
 
     if projekt_id:
         selected_projekt = get_object_or_404(Projekt, pk=projekt_id)
         objekte = selected_projekt.objekte.all().order_by('name')
+        projekt_form = ProjektForm(instance=selected_projekt)
         if objekt_id:
             selected_objekt = get_object_or_404(Objekt, pk=objekt_id, projekt=selected_projekt)
             messungen = selected_objekt.messungen.all().order_by('-erstellt_am')
+            objekt_form = ObjektForm(instance=selected_objekt)
+            objekt_form.fields['projekt'].queryset = Projekt.objects.filter(pk=selected_projekt.pk)
+            objekt_form.fields['projekt'].widget = forms.HiddenInput()
             if messung_id:
                 selected_messung = get_object_or_404(Messdaten, pk=messung_id, objekt=selected_objekt)
+                messung_form = MessungForm(instance=selected_messung)
 
     context = {
         'projekte': projekte,
         'selected_projekt': selected_projekt,
+        'projekt_form': projekt_form,
         'objekte': objekte,
         'selected_objekt': selected_objekt,
+        'objekt_form': objekt_form,
         'messungen': messungen,
         'selected_messung': selected_messung,
+        'messung_form': messung_form,
     }
     return render(request, 'messung/projekte_page.html', context)
 
@@ -134,7 +146,26 @@ def objekt_delete(request, objekt_id):
     return render(request, 'messung/objekt_confirm_delete.html', {'objekt': objekt})
 
 
+def messung_edit(request, messung_id):
+    messung = get_object_or_404(Messdaten, pk=messung_id)
+    if request.method == "POST":
+        form = MessungForm(request.POST, instance=messung)
+        if form.is_valid():
+            form.save()
+            return redirect("projekte_page")
+    else:
+        form = MessungForm(instance=messung)
+    return render(request, "messung/messung_form.html", {"form": form, "messung": messung})
 
+
+def messung_delete(request, messung_id):
+    messung = get_object_or_404(Messdaten, pk=messung_id)
+    if request.method == 'POST':
+        projekt_id = messung.objekt.projekt_id
+        objekt_id = messung.objekt_id
+        messung.delete()
+        return redirect(f"{reverse('projekte_page')}?projekt={projekt_id}&objekt={objekt_id}")
+    return render(request, 'messung/messung_confirm_delete.html', {'messung': messung})
 
 def create_anforderung(request):
     if request.method == 'POST':

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -86,6 +86,7 @@ a { color: inherit; text-decoration: none; }
 #sidebar-toggle svg { width:20px; height:20px; display:block; stroke:var(--svg-icon); }
 
 .sidebar-nav { display:flex; flex-direction:column; padding:.5rem; gap:.25rem; border-bottom:1px solid var(--color-border); overflow: hidden auto; }
+.sidebar-context .sidebar-nav { margin:0 -.6rem; border-bottom:none; }
 .nav-item { display:flex; align-items:center; gap:.6rem; padding:.45rem .6rem; border-radius:10px; min-height:36px; }
 .nav-item:hover { background:#2c2c2c; }
 .icon { display:inline-flex; width:20px; height:20px; align-items:center; justify-content:center; }
@@ -130,6 +131,7 @@ html.sidebar-collapsed .footer-btn, body.sidebar-collapsed .footer-btn {
 .card .edit-btn .icon, .card .edit-btn .icon svg { width:20px; height:20px; }
 .card.card-sub { margin-left:1rem; }
 .card.has-delete .edit-btn { right:2.5rem; }
+.card.has-delete { padding-right:2.5rem; }
 .card .delete-btn { position:absolute; top:.5rem; right:.5rem; background:transparent; border:none; width:28px; height:28px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; cursor:pointer; }
 .card .delete-btn:hover { background:#2c2c2c; }
 .card .delete-btn .icon, .card .delete-btn .icon svg { width:20px; height:20px; }
@@ -154,6 +156,17 @@ input, textarea, select {
 }
 
 form p { margin:0 0 1rem; }
+
+.form-row { display:grid; grid-template-columns:max-content 1fr; align-items:center; gap:.5rem; margin:0 0 1rem; }
+
+.icon-btn { background:transparent; border:1px solid var(--color-border); width:28px; height:28px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; padding:0; cursor:pointer; }
+.icon-btn .icon, .icon-btn .icon svg { width:20px; height:20px; }
+
+.edit-form .form-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:.5rem; }
+.edit-form .form-actions { display:flex; gap:.25rem; }
+.accordion-body.collapsed { display:none; }
+.accordion-toggle .icon svg { transition:transform .2s; }
+.accordion-toggle.collapsed .icon svg { transform:rotate(180deg); }
 
 /* Modal */
 .mm-btn { display:inline-flex; align-items:center; justify-content:center;


### PR DESCRIPTION
## Summary
- Replace save buttons with icon-only folder arrow buttons and add bordered styling
- Limit project description field to a single line and wrap sidebar edit forms in collapsible accordions
- Add per-item delete controls with confirmation prompts and support measurement deletion

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689b91bd4f6c8323bc4921e355e54093