### PR TITLE
Add measurement table and selection controls to measurement page

### DIFF
--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -5,6 +5,23 @@
   <link rel="stylesheet" href="{% static 'css/messung.css' %}">
 {% endblock %}
 {% block sidebar_context %}
+  <form id="selection-form" class="edit-form">
+    <div class="form-row">
+      <label for="project-select">Projektauswahl</label>
+      <select id="project-select" name="projekt">
+        <option value="">– bitte wählen –</option>
+        {% for projekt in projekte %}
+          <option value="{{ projekt.id }}">{{ projekt.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="form-row">
+      <label for="object-select">Objektauswahl</label>
+      <select id="object-select" name="objekt" disabled>
+        <option value="">– bitte wählen –</option>
+      </select>
+    </div>
+  </form>
   {% include "messung/messung_edit.html" %}
 {% endblock %}
 {% block content %}
@@ -21,6 +38,21 @@
         <span class="icon">{% include "icons/stop.svg" %}</span>
       </button>
     </div>
+  </section>
+
+  <section class="card">
+    <table class="measurement-table">
+      <thead>
+        <tr>
+          <th>Zeit</th>
+          <th>Einzelmessung</th>
+          <th>Kommentar</th>
+          <th>Sequenz_xy</th>
+          <th>Löschen</th>
+        </tr>
+      </thead>
+      <tbody id="measurement-table-body"></tbody>
+    </table>
   </section>
 {% endblock %}
 {% block extra_js %}

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -15,3 +15,22 @@
 #realtime-value {
   font-size: 1.5rem;
 }
+
+.measurement-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.measurement-table th,
+.measurement-table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.measurement-table th {
+  text-align: left;
+}
+
+.measurement-table td:last-child {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add project and object selection forms to measurement sidebar
- introduce measurement table with columns for time, value, comment, sequence and delete
- style measurement table for consistent appearance

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689c36075fb083239990468460f3b26d