### PR TITLE
Add measurement table and selection controls to measurement page

### DIFF
--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -5,7 +5,26 @@
   <link rel="stylesheet" href="{% static 'css/messung.css' %}">
 {% endblock %}
 {% block sidebar_context %}
-  {% include "messung/messung_edit.html" %}
+  <form id="selection-form" class="edit-form">
+    <div class="form-row">
+      <label for="project-select">Projektauswahl</label>
+      <select id="project-select" name="projekt">
+        <option value="">– bitte wählen –</option>
+        {% for projekt in projekte %}
+          <option value="{{ projekt.id }}">{{ projekt.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="form-row">
+      <label for="object-select">Objektauswahl</label>
+      <select id="object-select" name="objekt" disabled>
+        <option value="">– bitte wählen –</option>
+      </select>
+    </div>
+  </form>
+  {% if selected_messung %}
+    {% include "messung/messung_edit.html" %}
+  {% endif %}
 {% endblock %}
 {% block content %}
   <section class="card measurement-card">
@@ -21,6 +40,21 @@
         <span class="icon">{% include "icons/stop.svg" %}</span>
       </button>
     </div>
+  </section>
+
+  <section class="card">
+    <table class="measurement-table">
+      <thead>
+        <tr>
+          <th>Zeit</th>
+          <th>Einzelmessung</th>
+          <th>Kommentar</th>
+          <th>Sequenz_xy</th>
+          <th>Löschen</th>
+        </tr>
+      </thead>
+      <tbody id="measurement-table-body"></tbody>
+    </table>
   </section>
 {% endblock %}
 {% block extra_js %}

--- a/messung/tests.py
+++ b/messung/tests.py
@@ -1,3 +1,17 @@
 from django.test import TestCase
+from django.urls import reverse
 
-# Create your tests here.
+from .models import Projekt, Objekt, Messdaten
+
+
+class MessungPageTests(TestCase):
+    def setUp(self):
+        self.projekt = Projekt.objects.create(code="P1", name="Projekt 1")
+        self.objekt = Objekt.objects.create(projekt=self.projekt, nummer="1", name="Objekt 1")
+
+    def test_creates_new_messung_when_missing(self):
+        url = reverse('messung:page') + f'?objekt={self.objekt.id}'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)
+        messung = Messdaten.objects.get(objekt=self.objekt)
+        self.assertIn(f'messung={messung.id}', response['Location'])

--- a/messung/views.py
+++ b/messung/views.py
@@ -30,9 +30,34 @@ def messung_page(request):
     except (FileNotFoundError, subprocess.CalledProcessError) as e:
         print(f"Fehler bei lsusb: {e}")
         device_warning = True
+
     projekte = Projekt.objects.all().order_by('name')
     anforderungen = Anforderungen.objects.all().order_by('ref')
-    context = {'projekte': projekte, 'anforderungen': anforderungen, 'device_warning': device_warning}
+
+    objekt_id = request.GET.get('objekt')
+    messung_id = request.GET.get('messung')
+
+    selected_objekt = None
+    selected_messung = None
+    messung_form = None
+
+    if objekt_id:
+        selected_objekt = get_object_or_404(Objekt, pk=objekt_id)
+        if messung_id:
+            selected_messung = get_object_or_404(Messdaten, pk=messung_id, objekt=selected_objekt)
+            messung_form = MessungForm(instance=selected_messung)
+        else:
+            selected_messung = Messdaten.objects.create(objekt=selected_objekt, name="Neue Messung")
+            return redirect(f"{reverse('messung:page')}?objekt={selected_objekt.id}&messung={selected_messung.id}")
+
+    context = {
+        'projekte': projekte,
+        'anforderungen': anforderungen,
+        'device_warning': device_warning,
+        'selected_objekt': selected_objekt,
+        'selected_messung': selected_messung,
+        'messung_form': messung_form,
+    }
     return render(request, 'messung/messung_page.html', context)
 
 

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -15,3 +15,22 @@
 #realtime-value {
   font-size: 1.5rem;
 }
+
+.measurement-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.measurement-table th,
+.measurement-table td {
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.measurement-table th {
+  text-align: left;
+}
+
+.measurement-table td:last-child {
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add project and object selection forms to measurement sidebar
- introduce measurement table with columns for time, value, comment, sequence and delete
- style measurement table for consistent appearance
- load selected object and measurement in view and only render edit form when a measurement is selected
- automatically create a new measurement when an object is selected without an existing measurement

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689c36075fb083239990468460f3b26d