### PR TITLE
Keep project edit form visible on project page

### DIFF
--- a/messung/templates/messung/projekte_page.html
+++ b/messung/templates/messung/projekte_page.html
@@ -94,12 +94,9 @@
     });
   });
 
-  {% if selected_objekt %}
-  collapse('#projekt-fields');
-  {% endif %}
-  {% if selected_messung %}
-  collapse('#objekt-fields');
-  {% endif %}
+    {% if selected_messung %}
+    collapse('#objekt-fields');
+    {% endif %}
 
   document.querySelectorAll('.edit-form').forEach(form => {
     const saveBtn = form.querySelector('.save-btn');


### PR DESCRIPTION
## Summary
- ensure project edit form stays expanded on the projects page by removing automatic collapse when an object is selected

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689d8c4a99b0832393d32b5d876e11a7