### PR TITLE
Add open button for measurements and remove add button

### DIFF
--- a/messung/templates/messung/messung_edit.html
+++ b/messung/templates/messung/messung_edit.html
@@ -9,9 +9,10 @@
       {% endfor %}
     </select>
     <div class="form-actions">
-      <button type="button" class="icon-btn add-btn" title="Messung hinzufügen">
-        <span class="icon">{% include "icons/document-plus.svg" %}</span>
-      </button>
+      <a href="{% url 'messung:page' %}?objekt={{ selected_objekt.id }}{% if selected_messung %}&messung={{ selected_messung.id }}{% endif %}"
+         class="icon-btn" title="Messung öffnen">
+        <span class="icon">{% include "icons/folder-open.svg" %}</span>
+      </a>
       <button type="submit" class="icon-btn save-btn" title="Speichern" disabled>
         <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
       </button>


### PR DESCRIPTION
## Summary
- replace project-page measurement add button with an open link to the measurement page

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689d9e46adac8323841708e7e9e14713