### PR TITLE
feat: expand measurement sequence UI

### DIFF
--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -26,8 +26,8 @@
     </div>
   </form>
   <div class="device-connection">
-    <button type="button" class="mm-btn mm-btn--primary" id="device-connect" title="Messgerät verbinden">
-      <span class="icon">{% include "icons/link.svg" %}</span>
+    <button type="button" class="mm-btn mm-btn--ghost" id="device-connect" title="Messgerät verbinden">
+      <span class="icon">{% include "icons/arrow-path-rounded-square.svg" %}</span>
     </button>
     <span id="device-status">{{ device_status }}</span>
   </div>
@@ -38,17 +38,21 @@
 {% block content %}
   <section class="card measurement-card">
     <div class="measurement-main">
-      <button type="button" class="mm-btn mm-btn--primary" id="single-measure" title="Einzelmessung">
+      <button type="button" class="mm-btn mm-btn--ghost" id="single-measure" title="Einzelmessung">
         <span class="icon">{% include "icons/camera.svg" %}</span>
       </button>
       <span id="realtime-value">0.00</span>
     </div>
     <div class="measurement-controls">
-      <button type="button" class="mm-btn mm-btn--primary" id="sequence-start" title="Messsequenz starten">
+      <button type="button" class="mm-btn mm-btn--ghost" id="sequence-start" title="Messsequenz starten">
         <span class="icon">{% include "icons/play.svg" %}</span>
       </button>
       <button type="button" class="mm-btn mm-btn--ghost" id="sequence-stop" title="Messsequenz stoppen">
         <span class="icon">{% include "icons/stop.svg" %}</span>
+      </button>
+      <select id="sequence-select"></select>
+      <button type="button" class="mm-btn mm-btn--ghost" id="sequence-add" title="Neue Messsequenz">
+        <span class="icon">{% include "icons/document-plus.svg" %}</span>
       </button>
     </div>
   </section>
@@ -60,8 +64,7 @@
           <th>Zeit</th>
           <th>Einzelmessung</th>
           <th>Kommentar</th>
-          <th>Sequenz_xy</th>
-          <th>Löschen</th>
+          <th class="delete-column"></th>
         </tr>
       </thead>
       <tbody id="measurement-table-body"></tbody>

--- a/static/js/messung.js
+++ b/static/js/messung.js
@@ -21,26 +21,95 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  const statusSpan = document.getElementById('device-status');
-  const realtimeSpan = document.getElementById('realtime-value');
-  const tableBody = document.getElementById('measurement-table-body');
+    const statusSpan = document.getElementById('device-status');
+    const realtimeSpan = document.getElementById('realtime-value');
+    const tableBody = document.getElementById('measurement-table-body');
+    const headerRow = document.querySelector('.measurement-table thead tr');
 
-  const wsScheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
-  const socket = new WebSocket(`${wsScheme}://${window.location.host}/ws/messung/`);
+    const seqSelect = document.getElementById('sequence-select');
+    const seqAddBtn = document.getElementById('sequence-add');
+    const sequences = {};
+    const sequenceOrder = [];
+    let seqCounter = 0;
+    let activeSeqKey = null;
 
-  socket.onmessage = (event) => {
-    const msg = JSON.parse(event.data);
-    if (msg.type === 'status.update' && statusSpan) {
-      statusSpan.textContent = msg.data.text;
-    } else if (msg.type === 'realtime.value' && realtimeSpan) {
-      realtimeSpan.textContent = Number(msg.data.value).toFixed(2);
-    } else if (msg.type === 'measurement.value' && tableBody) {
-      const value = Number(msg.data.value).toFixed(2);
-      const row = document.createElement('tr');
-      row.innerHTML = `<td>${msg.data.time}</td><td>${value}</td><td></td><td></td><td></td>`;
-      tableBody.appendChild(row);
+    function addSequenceColumn() {
+      const key = `seq${++seqCounter}`;
+      sequenceOrder.push(key);
+      const th = document.createElement('th');
+      const input = document.createElement('input');
+      input.type = 'text';
+      input.value = `Sequenz ${seqCounter}`;
+      th.appendChild(input);
+      headerRow.insertBefore(th, headerRow.querySelector('.delete-column'));
+      Array.from(tableBody.rows).forEach(row => {
+        row.insertBefore(document.createElement('td'), row.lastElementChild);
+      });
+      const option = document.createElement('option');
+      option.value = key;
+      option.textContent = input.value;
+      seqSelect.appendChild(option);
+      sequences[key] = { input, option, id: null };
+      input.addEventListener('input', () => { option.textContent = input.value; });
+      if (!seqSelect.value) seqSelect.value = key;
     }
-  };
+
+    if (seqAddBtn && seqSelect) {
+      seqAddBtn.addEventListener('click', addSequenceColumn);
+      seqSelect.addEventListener('change', () => {
+        activeSeqKey = seqSelect.value;
+      });
+    }
+
+    const wsScheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const socket = new WebSocket(`${wsScheme}://${window.location.host}/ws/messung/`);
+
+    socket.onmessage = (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.type === 'status.update' && statusSpan) {
+        statusSpan.textContent = msg.data.text;
+      } else if (msg.type === 'realtime.value' && realtimeSpan) {
+        realtimeSpan.textContent = Number(msg.data.value).toFixed(2);
+      } else if (msg.type === 'sequence.start') {
+        if (activeSeqKey && sequences[activeSeqKey]) {
+          sequences[activeSeqKey].id = msg.data.id;
+        }
+      } else if (msg.type === 'measurement.value' && tableBody) {
+        const value = Number(msg.data.value).toFixed(2);
+        const row = document.createElement('tr');
+        const timeTd = document.createElement('td');
+        timeTd.textContent = msg.data.time;
+        row.appendChild(timeTd);
+        const singleTd = document.createElement('td');
+        row.appendChild(singleTd);
+        const commentTd = document.createElement('td');
+        const commentInput = document.createElement('input');
+        commentInput.type = 'text';
+        commentTd.appendChild(commentInput);
+        row.appendChild(commentTd);
+        sequenceOrder.forEach(() => {
+          row.appendChild(document.createElement('td'));
+        });
+        const deleteTd = document.createElement('td');
+        const delBtn = document.createElement('button');
+        delBtn.type = 'button';
+        delBtn.className = 'icon-btn delete-row';
+        delBtn.innerHTML = '<span class="icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="svg-icon" stroke="var(--svg-icon)" d="M14.7404 9L14.3942 18M9.60577 18L9.25962 9M19.2276 5.79057C19.5696 5.84221 19.9104 5.89747 20.25 5.95629M19.2276 5.79057L18.1598 19.6726C18.0696 20.8448 17.0921 21.75 15.9164 21.75H8.08357C6.90786 21.75 5.93037 20.8448 5.8402 19.6726L4.77235 5.79057M19.2276 5.79057C18.0812 5.61744 16.9215 5.48485 15.75 5.39432M3.75 5.95629C4.08957 5.89747 4.43037 5.84221 4.77235 5.79057M4.77235 5.79057C5.91878 5.61744 7.07849 5.48485 8.25 5.39432M15.75 5.39432V4.47819C15.75 3.29882 14.8393 2.31423 13.6606 2.27652C13.1092 2.25889 12.5556 2.25 12 2.25C11.4444 2.25 10.8908 2.25889 10.3394 2.27652C9.16065 2.31423 8.25 3.29882 8.25 4.47819V5.39432M15.75 5.39432C14.5126 5.2987 13.262 5.25 12 5.25C10.738 5.25 9.48744 5.2987 8.25 5.39432" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>';
+        delBtn.addEventListener('click', () => row.remove());
+        deleteTd.appendChild(delBtn);
+        row.appendChild(deleteTd);
+        if (msg.data.is_sequence) {
+          const seqKey = sequenceOrder.find(k => sequences[k].id === msg.data.sequence_id);
+          if (seqKey) {
+            const idx = sequenceOrder.indexOf(seqKey);
+            row.children[3 + idx].textContent = value;
+          }
+        } else {
+          singleTd.textContent = value;
+        }
+        tableBody.appendChild(row);
+      }
+    };
 
   const connectBtn = document.getElementById('device-connect');
   if (connectBtn) {
@@ -51,25 +120,45 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  const singleBtn = document.getElementById('single-measure');
-  if (singleBtn) {
-    singleBtn.addEventListener('click', () => {
-      fetch('/messung/api/single/').catch(err => console.error(err));
-    });
-  }
+    const singleBtn = document.getElementById('single-measure');
+    if (singleBtn) {
+      singleBtn.addEventListener('click', () => {
+        fetch('/messung/api/single/').catch(err => console.error(err));
+      });
+    }
 
-  const seqStartBtn = document.getElementById('sequence-start');
-  if (seqStartBtn) {
-    seqStartBtn.addEventListener('click', () => {
-      fetch('/messung/api/start/').catch(err => console.error(err));
-    });
-  }
+    const seqStartBtn = document.getElementById('sequence-start');
+    if (seqStartBtn) {
+      seqStartBtn.addEventListener('click', () => {
+        if (seqSelect && seqSelect.value) {
+          activeSeqKey = seqSelect.value;
+          const name = sequences[activeSeqKey]?.input.value || '';
+          fetch(`/messung/api/start/?name=${encodeURIComponent(name)}`).catch(err => console.error(err));
+        }
+      });
+    }
 
-  const seqStopBtn = document.getElementById('sequence-stop');
-  if (seqStopBtn) {
-    seqStopBtn.addEventListener('click', () => {
-      fetch('/messung/api/stop/').catch(err => console.error(err));
-    });
-  }
-});
+    const seqStopBtn = document.getElementById('sequence-stop');
+    if (seqStopBtn) {
+      seqStopBtn.addEventListener('click', () => {
+        fetch('/messung/api/stop/').catch(err => console.error(err));
+      });
+    }
+
+    const editForm = document.getElementById('messung-edit-form');
+    if (editForm) {
+      const saveBtn = editForm.querySelector('.save-btn');
+      if (saveBtn) {
+        saveBtn.disabled = true;
+        editForm.addEventListener('input', () => {
+          saveBtn.disabled = false;
+          saveBtn.classList.add('unsaved');
+        });
+        editForm.addEventListener('submit', () => {
+          saveBtn.classList.remove('unsaved');
+          saveBtn.disabled = true;
+        });
+      }
+    }
+  });
 


### PR DESCRIPTION
## Summary
- remove button backgrounds and update connect icon
- add dynamic sequence columns with add/select controls
- allow saving measurement form

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689db4d8e3e483238573562296488f40