### PR TITLE
Refine measurement context menu and button styling

### DIFF
--- a/messung/templates/messung/messung_edit.html
+++ b/messung/templates/messung/messung_edit.html
@@ -13,6 +13,9 @@
          class="icon-btn" title="Messung öffnen">
         <span class="icon">{% include "icons/folder-open.svg" %}</span>
       </a>
+      <button type="button" class="icon-btn new-btn" title="Neue Messung">
+        <span class="icon">{% include "icons/document-plus.svg" %}</span>
+      </button>
       <button type="submit" class="icon-btn save-btn" title="Speichern" disabled>
         <span class="icon">{% include "icons/folder-arrow-down.svg" %}</span>
       </button>

--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -5,6 +5,12 @@
   <link rel="stylesheet" href="{% static 'css/messung.css' %}">
 {% endblock %}
 {% block sidebar_context %}
+  <div class="device-connection">
+    <button type="button" class="icon-btn" id="device-connect" title="Messgerät verbinden">
+      <span class="icon">{% include "icons/arrow-path-rounded-square.svg" %}</span>
+    </button>
+    <span id="device-status">{{ device_status }}</span>
+  </div>
   <form id="selection-form" class="edit-form" method="get">
     <div class="form-row">
       <label for="project-select">Projektauswahl</label>
@@ -25,12 +31,6 @@
       </select>
     </div>
   </form>
-  <div class="device-connection">
-    <button type="button" class="mm-btn mm-btn--ghost" id="device-connect" title="Messgerät verbinden">
-      <span class="icon">{% include "icons/arrow-path-rounded-square.svg" %}</span>
-    </button>
-    <span id="device-status">{{ device_status }}</span>
-  </div>
   {% if selected_messung %}
     {% include "messung/messung_edit.html" %}
   {% endif %}
@@ -38,20 +38,20 @@
 {% block content %}
   <section class="card measurement-card">
     <div class="measurement-main">
-      <button type="button" class="mm-btn mm-btn--ghost" id="single-measure" title="Einzelmessung">
+      <button type="button" class="icon-btn" id="single-measure" title="Einzelmessung">
         <span class="icon">{% include "icons/camera.svg" %}</span>
       </button>
       <span id="realtime-value">0.00</span>
     </div>
     <div class="measurement-controls">
-      <button type="button" class="mm-btn mm-btn--ghost" id="sequence-start" title="Messsequenz starten">
+      <button type="button" class="icon-btn" id="sequence-start" title="Messsequenz starten">
         <span class="icon">{% include "icons/play.svg" %}</span>
       </button>
-      <button type="button" class="mm-btn mm-btn--ghost" id="sequence-stop" title="Messsequenz stoppen">
+      <button type="button" class="icon-btn" id="sequence-stop" title="Messsequenz stoppen">
         <span class="icon">{% include "icons/stop.svg" %}</span>
       </button>
       <select id="sequence-select"></select>
-      <button type="button" class="mm-btn mm-btn--ghost" id="sequence-add" title="Neue Messsequenz">
+      <button type="button" class="icon-btn" id="sequence-add" title="Neue Messsequenz">
         <span class="icon">{% include "icons/document-plus.svg" %}</span>
       </button>
     </div>

--- a/messung/views.py
+++ b/messung/views.py
@@ -191,7 +191,7 @@ def messung_edit(request, messung_id):
         form = MessungForm(request.POST, instance=messung)
         if form.is_valid():
             form.save()
-    return redirect("projekte_page")
+    return redirect(f"{reverse('messung:page')}?projekt={messung.objekt.projekt.id}&objekt={messung.objekt.id}&messung={messung.id}")
 
 def messung_delete(request, messung_id):
     messung = get_object_or_404(Messdaten, pk=messung_id)
@@ -210,9 +210,11 @@ def messung_create(request, objekt_id):
         if form.is_valid():
             messung = form.save(commit=False)
             messung.objekt = objekt
+            if not messung.name:
+                messung.name = "Neue Messung"
             messung.save()
-            return redirect(f"{reverse('projekte_page')}?projekt={objekt.projekt.id}&objekt={objekt.id}&messung={messung.id}")
-    return redirect(f"{reverse('projekte_page')}?projekt={objekt.projekt.id}&objekt={objekt.id}")
+            return redirect(f"{reverse('messung:page')}?projekt={objekt.projekt.id}&objekt={objekt.id}&messung={messung.id}")
+    return redirect(f"{reverse('messung:page')}?projekt={objekt.projekt.id}&objekt={objekt.id}")
 
 def create_anforderung(request):
     if request.method == 'POST':

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -6,7 +6,7 @@
 .measurement-main {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.5rem;
 }
 .measurement-controls {
   display: flex;
@@ -16,23 +16,12 @@
   font-size: 1.5rem;
 }
 
-.measurement-card .mm-btn {
-  width: 40px;
-  height: 40px;
-  min-width: 40px;
-  padding: 0;
-}
-.measurement-card .mm-btn .icon,
-.measurement-card .mm-btn .icon svg {
-  width: 20px;
-  height: 20px;
-}
+
 
 .device-connection {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  margin-top: 1rem;
 }
 
 .measurement-table {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -155,21 +155,22 @@ input, textarea, select {
   color: var(--color-text);
   border-radius: 8px;
   padding: .4rem;
-  width: 100%;
+  width: calc(100% - 1rem);
+  margin: 0 .5rem;
 }
 
 form p { margin:0 0 1rem; }
 
 .form-row { display:grid; grid-template-columns:max-content 1fr; align-items:center; gap:.5rem; margin:0 0 1rem; }
 
-.icon-btn { background:transparent; border:1px solid var(--color-border); width:28px; height:28px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; padding:.5rem; cursor:pointer; }
+.icon-btn { background:transparent; border:1px solid var(--color-border); width:30px; height:30px; min-width:30px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; padding:.5rem; cursor:pointer; }
 .icon-btn .icon, .icon-btn .icon svg { width:20px; height:20px; }
 .icon-btn:disabled {cursor:default; }
 .icon-btn:disabled .icon svg { stroke: var(--secondary); }
 .save-btn.unsaved { border-color: red; }
 
 .edit-form .form-header { display:flex; justify-content:space-between; align-items:center; margin-bottom:.5rem; color: var(--primary); }
-.edit-form .form-actions { display:flex; gap:.25rem; }
+.edit-form .form-actions { display:flex; gap:.5rem; }
 .accordion-body.collapsed { display:none; }
 .accordion-toggle .icon svg { transition:transform .2s; }
 .accordion-toggle.collapsed .icon svg { transform:rotate(180deg); }

--- a/static/js/messung.js
+++ b/static/js/messung.js
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const delBtn = document.createElement('button');
       delBtn.type = 'button';
       delBtn.className = 'icon-btn delete-row';
-      delBtn.innerHTML = '<span class="icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="svg-icon" stroke="var(--svg-icon)" d="M14.7404 9L14.3942 18M9.60577 18L9.25962 9M19.2276 5.79057C19.5696 5.84221 19.9104 5.89747 20.25 5.95629M19.2276 5.79057L18.1598 19.6726C18.0696 20.8448 17.0921 21.75 15.9164 21.75H8.08357C6.90786 21.75 5.93037 20.8448 5.8402 19.6726L4.77235 5.79057M19.2276 5.79057C18.0812 5.61744 16.9215 5.48485 15.75 5.39432M3.75 5.95629C4.08957 5.89747 4.43037 5.84221 4.77235 5.79057M4.77235 5.79057C5.91878 5.61744 7.07849 5.48485 8.25 5.39432M15.75 5.39432V4.47819C15.75 3.29882 14.8393 2.31423 13.6606 2.27652C13.1092 2.25889 12.5556 2.25 12 2.25C11.4444 2.25 10.8908 2.25889 10.3394 2.27652C9.16065 2.31423 8.25 3.29882 8.25 4.47819V5.39432M15.75 5.39432C14.5126 5.2987 13.262 5.25 12 5.25C10.738 5.25 9.48744 5.2987 8.25 5.39432" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>';
+      delBtn.innerHTML = '<span class="icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="svg-icon" stroke="var(--svg-icon)" d="M14.7404 9L14.3942 18M9.60577 18L9.25962 9M19.2276 5.79057C19.5696 5.84221 19.9104 5.89747 20.25 5.95629M19.2276 5.79057L18.1598 19.6726C18.0696 20.8448 17.0921 21.75 15.9164 21.75H8.08357C6.90786 21.75 5.93037 20.8448 5.8402 19.6726L4.77235 5.79057M19.2276 5.79057C18.0812 5.61744 16.9215 5.48485 15.75 5.39432M3.75 5.95629C4.08957 5.89747 4.43037 5.84221 4.77235 5.79057M4.77235 5.79057C5.91878 5.61744 7.07849 5.48485 8.25 5.39432M15.75 5.39432V4.47819C15.75 3.29882 14.8393 2.31423 13.6606 2.27652C13.1092 2.25889 12.5556 2.25 12 2.25C11.4444 2.25 10.8908 2.25889 10.3394 2.27652C9.16065 2.31423 8.25 3.29882 8.25 4.47819V5.39432M15.75 5.39432C14.5126 5.2987 13.262 5.25 12 5.25C10.738 5.25 9.48744 5.2987 8.25 5.39432" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>';
       delBtn.addEventListener('click', () => {
         if (window.mmModal && window.mmModal.open) {
           window.mmModal.open({
@@ -189,6 +189,38 @@ document.addEventListener('DOMContentLoaded', () => {
         editForm.addEventListener('submit', () => {
           saveBtn.classList.remove('unsaved');
           saveBtn.disabled = true;
+        });
+      }
+
+      const messungSelect = document.getElementById('messung-select');
+      if (messungSelect) {
+        messungSelect.addEventListener('change', e => {
+          const id = e.target.value;
+          const params = new URLSearchParams(window.location.search);
+          if (id) {
+            params.set('messung', id);
+          } else {
+            params.delete('messung');
+          }
+          window.location.search = params.toString();
+        });
+      }
+
+      const newBtn = editForm.querySelector('.new-btn');
+      if (newBtn) {
+        newBtn.addEventListener('click', () => {
+          const url = editForm.dataset.createUrl;
+          const csrf = editForm.querySelector('input[name=csrfmiddlewaretoken]').value;
+          const tmpForm = document.createElement('form');
+          tmpForm.method = 'post';
+          tmpForm.action = url;
+          const csrfInput = document.createElement('input');
+          csrfInput.type = 'hidden';
+          csrfInput.name = 'csrfmiddlewaretoken';
+          csrfInput.value = csrf;
+          tmpForm.appendChild(csrfInput);
+          document.body.appendChild(tmpForm);
+          tmpForm.submit();
         });
       }
     }


### PR DESCRIPTION
## Summary
- Fix saving and creation redirects for measurements
- Add new measurement button and selection behavior
- Unify button and input spacing with consistent 30x30 icon buttons

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_689f8c70588c832389d66a2b8d648823