### PR TITLE
Streamline measurement model and comment handling

### DIFF
--- a/messung/models.py
+++ b/messung/models.py
@@ -43,38 +43,11 @@ class Messdaten(models.Model):
     anforderung = models.ForeignKey(Anforderungen, on_delete=models.SET_NULL, blank=True, null=True)
     name = models.CharField(max_length=100, help_text="Name der Messung")
     messdaten = models.JSONField(default=list, help_text="Liste von Messpunkten")
-    kommentar = models.TextField(blank=True, null=True)
     device = models.CharField(max_length=255, blank=True, null=True)
     einheit = models.CharField(max_length=50, blank=True, null=True)
     messbedingungen = models.TextField(blank=True, null=True)
-    messhoehe = models.FloatField(blank=True, null=True)
-    min_wert = models.FloatField(blank=True, null=True)
-    max_wert = models.FloatField(blank=True, null=True)
-    avg_wert = models.FloatField(blank=True, null=True)
-    u0 = models.FloatField(blank=True, null=True, help_text="Gleichmässigkeit (min/avg)")
+    messhoehe = models.FloatField(default=0.75, blank=True, null=True)
     erstellt_am = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
         return f"{self.name} für Objekt {self.objekt.name}"
-
-    def save(self, *args, **kwargs):
-        self.min_wert, self.max_wert, self.avg_wert, self.u0 = None, None, None, None
-        werte = []
-        if self.messdaten:
-            if isinstance(self.messdaten, list):
-                werte = [float(punkt['value']) for punkt in self.messdaten if 'value' in punkt]
-            elif isinstance(self.messdaten, dict):
-                for row in self.messdaten.get('data', []):
-                    single = row.get('single')
-                    if single not in (None, ''):
-                        werte.append(float(single))
-                    for val in row.get('sequences', []):
-                        if val not in (None, ''):
-                            werte.append(float(val))
-        if werte:
-            self.min_wert = min(werte)
-            self.max_wert = max(werte)
-            self.avg_wert = sum(werte) / len(werte)
-            if self.avg_wert:
-                self.u0 = self.min_wert / self.avg_wert
-        super().save(*args, **kwargs)

--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -68,7 +68,7 @@
         <tr>
           <th>Zeit</th>
           <th>Einzelmessung</th>
-          <th>Kommentar</th>
+          <th class="comment-column"><button type="button" class="comment-toggle" data-index="0">Kommentar</button></th>
           <th class="delete-column"></th>
         </tr>
       </thead>

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -39,6 +39,11 @@
   text-align: left;
 }
 
+.comment-column .comment-toggle {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.5rem;
+}
+
 .measurement-table td:last-child {
   text-align: center;
 }
@@ -56,4 +61,22 @@
   background: rgba(0, 0, 0, 0.1);
   pointer-events: none;
   z-index: 1000;
+}
+
+#column-context-menu {
+  position: absolute;
+  display: none;
+  background: var(--color-bg, #fff);
+  border: 1px solid var(--color-border);
+  padding: 0.5rem;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}
+#column-context-menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+#column-context-menu li {
+  padding: 0.2rem 0;
 }


### PR DESCRIPTION
## Summary
- Drop redundant statistic fields from measurements and default `messhoehe` to 0.75
- Rework measurement table to pair each value column with a togglable comment column
- Compute export stats directly from JSON and include per-column comments

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689faa50295483238c8c3753b32c5bb2