### PR TITLE
Prevent screen timeout and add requirement search

### DIFF
--- a/messung/templates/messung/messung_edit.html
+++ b/messung/templates/messung/messung_edit.html
@@ -30,7 +30,16 @@
       {{ messung_form.name.label_tag }} {{ messung_form.name }}
     </div>
     <div class="form-row">
-      {{ messung_form.anforderung.label_tag }} {{ messung_form.anforderung }}
+      {{ messung_form.anforderung.label_tag }}
+      <input type="hidden" name="anforderung" id="id_anforderung" value="{{ messung_form.anforderung.value|default:'' }}">
+      <button type="button" class="icon-btn" id="anforderung-open" title="Anforderung wählen">
+        <span class="icon">{% include "icons/magnifying-glass.svg" %}</span>
+      </button>
+      <span id="anforderung-display">
+        {% if selected_messung and selected_messung.anforderung %}
+          {{ selected_messung.anforderung.ref }}{% if selected_messung.anforderung.typ %} {{ selected_messung.anforderung.typ }}{% endif %}
+        {% else %}–{% endif %}
+      </span>
     </div>
     <div class="form-row">
       {{ messung_form.messbedingungen.label_tag }} {{ messung_form.messbedingungen }}
@@ -40,3 +49,11 @@
     </div>
   </div>
 </form>
+
+<div id="anforderung-modal" class="anforderung-modal">
+  <div class="modal-content">
+    <input type="text" id="anforderung-search" placeholder="Suche...">
+    <div id="anforderung-results"></div>
+    <button type="button" id="anforderung-close" class="icon-btn">Schließen</button>
+  </div>
+</div>

--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -86,6 +86,7 @@
 {% block extra_js %}
   <script>
     window.initialTable = {{ initial_table|safe }};
+    window.anforderungenData = {{ anforderungen_json|safe }};
   </script>
   <script src="{% static 'js/messung.js' %}"></script>
 {% endblock %}

--- a/messung/views.py
+++ b/messung/views.py
@@ -32,7 +32,8 @@ def messung_page(request):
         device_warning = True
 
     projekte = Projekt.objects.all().order_by('name')
-    anforderungen = Anforderungen.objects.all().order_by('ref')
+    anforderungen_qs = Anforderungen.objects.all().order_by('ref')
+    anforderungen_json = json.dumps(list(anforderungen_qs.values('id', 'ref', 'bereich', 'typ')))
 
     projekt_id = request.GET.get('projekt')
     objekt_id = request.GET.get('objekt')
@@ -73,7 +74,8 @@ def messung_page(request):
         'projekte': projekte,
         'objekte': objekte,
         'selected_projekt': selected_projekt,
-        'anforderungen': anforderungen,
+        'anforderungen': anforderungen_qs,
+        'anforderungen_json': anforderungen_json,
         'device_warning': device_warning,
         'device_status': device_status,
         'selected_objekt': selected_objekt,

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -97,3 +97,41 @@
 #column-context-menu li {
   padding: 0.2rem 0;
 }
+
+.anforderung-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 1500;
+}
+
+.anforderung-modal .modal-content {
+  background: var(--color-bg, #fff);
+  padding: 1rem;
+  max-height: 80vh;
+  overflow: auto;
+  width: 80%;
+  max-width: 400px;
+}
+
+#anforderung-results .bereich {
+  font-weight: bold;
+  margin-top: 0.5rem;
+}
+
+#anforderung-results ul {
+  list-style: none;
+  margin: 0;
+  padding-left: 1rem;
+}
+
+#anforderung-results li {
+  cursor: pointer;
+  padding: 0.2rem 0;
+}


### PR DESCRIPTION
## Summary
- prevent screen from sleeping during measurements
- add searchable popup to pick requirements grouped by area

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a087ccff9c832389c66134b2ec1155