### PR TITLE
Show measurement data on project page

### DIFF
--- a/messung/templates/messung/messung_edit.html
+++ b/messung/templates/messung/messung_edit.html
@@ -10,10 +10,6 @@
       {% endfor %}
     </select>
     <div class="form-actions">
-      <a href="{% url 'messung:page' %}?objekt={{ selected_objekt.id }}{% if selected_messung %}&messung={{ selected_messung.id }}{% endif %}"
-         class="icon-btn" title="Messung öffnen">
-        <span class="icon">{% include "icons/folder-open.svg" %}</span>
-      </a>
       <button type="button" class="icon-btn new-btn" title="Neue Messung">
         <span class="icon">{% include "icons/document-plus.svg" %}</span>
       </button>

--- a/messung/templates/messung/projekte_page.html
+++ b/messung/templates/messung/projekte_page.html
@@ -5,9 +5,6 @@
   {% if selected_projekt %}
     {% include "messung/objekt_edit.html" %}
   {% endif %}
-  {% if selected_objekt %}
-    {% include "messung/messung_edit.html" %}
-  {% endif %}
 {% endblock %}
 {% block content %}
   <div class="element-columns">
@@ -50,9 +47,12 @@
     <div class="column">
       {% if selected_objekt %}
         {% for messung in messungen %}
-          <section class="card element-card messung-card has-delete{% if selected_messung and messung.id == selected_messung.id %} selected{% endif %}">
+          <section class="card element-card messung-card has-delete has-open{% if selected_messung and messung.id == selected_messung.id %} selected{% endif %}">
             <a href="{% url 'projekte_page' %}?projekt={{ selected_projekt.id }}&objekt={{ selected_objekt.id }}&messung={{ messung.id }}">
               <h4>{{ messung.name }}</h4>
+            </a>
+            <a href="{% url 'messung:page' %}?objekt={{ selected_objekt.id }}&messung={{ messung.id }}" class="open-btn" title="Messung öffnen">
+              <span class="icon">{% include "icons/folder-open.svg" %}</span>
             </a>
             <form method="post" action="{% url 'messung_delete' messung.id %}">
               {% csrf_token %}
@@ -67,6 +67,30 @@
       {% endif %}
     </div>
   </div>
+  {% if selected_messung %}
+    <section class="card">
+      <table class="measurement-table">
+        <thead>
+          <tr>
+            <th>Zeit</th>
+            <th>Wert</th>
+            <th>Kommentar</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for punkt in messpunkte %}
+          <tr>
+            <td>{{ punkt.time }}</td>
+            <td>{{ punkt.value }}</td>
+            <td>{{ punkt.comment }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="3">Keine Messdaten vorhanden.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+  {% endif %}
 {% endblock %}
 {% block extra_js %}
 {% if selected_projekt or selected_objekt or selected_messung %}
@@ -154,7 +178,6 @@
   });
 
   const selectedProjektId = {{ selected_projekt.id|default:"null" }};
-  const selectedObjektId = {{ selected_objekt.id|default:"null" }};
 
   const projektSelect = document.getElementById('projekt-select');
   if(projektSelect){
@@ -172,16 +195,6 @@
       const id = e.target.value;
       if(id){
         window.location.href = `?projekt=${selectedProjektId}&objekt=${id}`;
-      }
-    });
-  }
-
-  const messungSelect = document.getElementById('messung-select');
-  if(messungSelect){
-    messungSelect.addEventListener('change', e => {
-      const id = e.target.value;
-      if(id){
-        window.location.href = `?projekt=${selectedProjektId}&objekt=${selectedObjektId}&messung=${id}`;
       }
     });
   }

--- a/messung/views.py
+++ b/messung/views.py
@@ -120,14 +120,6 @@ def projekte_page(request):
         objekt_form.fields['projekt'].queryset = Projekt.objects.filter(pk=selected_projekt.pk)
         objekt_form.fields['projekt'].widget = forms.HiddenInput()
 
-    messung_form = None
-    if selected_objekt:
-        messung_form = (
-            MessungForm(instance=selected_messung)
-            if selected_messung
-            else MessungForm()
-        )
-
     context = {
         'projekte': projekte,
         'selected_projekt': selected_projekt,
@@ -137,8 +129,14 @@ def projekte_page(request):
         'objekt_form': objekt_form,
         'messungen': messungen,
         'selected_messung': selected_messung,
-        'messung_form': messung_form,
     }
+
+    messpunkte = []
+    if selected_messung:
+        data = selected_messung.messdaten
+        messpunkte = data.get('data', []) if isinstance(data, dict) else data
+
+    context['messpunkte'] = messpunkte
     return render(request, 'messung/projekte_page.html', context)
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -134,6 +134,12 @@ html.sidebar-collapsed .footer-btn, body.sidebar-collapsed .footer-btn {
 .card.card-sub { margin-left:1rem; }
 .card.has-delete .edit-btn { right:2.5rem; }
 .card.has-delete { padding-right:2.5rem; }
+.card .open-btn { position:absolute; top:.5rem; right:.5rem; background:transparent; border:none; width:28px; height:28px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; cursor:pointer; }
+.card .open-btn:hover { background:#2c2c2c; }
+.card .open-btn .icon, .card .open-btn .icon svg { width:20px; height:20px; }
+.card.has-delete .open-btn { right:2.5rem; }
+.card.has-open { padding-right:2.5rem; }
+.card.has-delete.has-open { padding-right:5rem; }
 .card .delete-btn { position:absolute; top:.5rem; right:.5rem; background:transparent; border:none; width:28px; height:28px; border-radius:6px; display:inline-flex; align-items:center; justify-content:center; cursor:pointer; }
 .card .delete-btn:hover { background:#2c2c2c; }
 .card .delete-btn .icon, .card .delete-btn .icon svg { width:20px; height:20px; }


### PR DESCRIPTION
## Summary
- remove measurement edit form from project overview
- move measurement open action onto each measurement card
- show measurement values below cards when a measurement is selected

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0cf849b30832390f9db2a4ace0e13