### PR TITLE
Improve measurement page layout and controls

### DIFF
--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -43,29 +43,33 @@
         <span class="icon">{% include "icons/document-plus.svg" %}</span>
       </button>
     </div>
-    <div class="measurement-main">
-      <button type="button" class="icon-btn" id="single-measure" title="Einzelmessung">
-        <span class="icon">{% include "icons/camera.svg" %}</span>
-      </button>
-      <span id="realtime-value">0.00</span>
-    </div>
-    <div class="control-buttons">
-      <button type="button" class="icon-btn" id="sequence-start" title="Messreihe starten">
-        <span class="icon">{% include "icons/play.svg" %}</span>
-      </button>
-      <button type="button" class="icon-btn" id="sequence-stop" title="Messreihe stoppen">
-        <span class="icon">{% include "icons/stop.svg" %}</span>
-      </button>
-    </div>
-    <span id="sequence-duration"></span>
-    <div class="range-controls">
-      <div class="range-group">
-        <label for="sequence-interval">Intervall (s): <span id="sequence-interval-display">5</span></label>
-        <input type="range" id="sequence-interval" min="1" max="10" value="5">
+    <div class="controls-row">
+      <div class="measurement-main">
+        <button type="button" class="icon-btn" id="single-measure" title="Einzelmessung">
+          <span class="icon">{% include "icons/camera.svg" %}</span>
+        </button>
+        <span id="realtime-value">0.00</span>
       </div>
-      <div class="range-group">
-        <label for="sequence-count">Anzahl: <span id="sequence-count-display">5</span></label>
-        <input type="range" id="sequence-count" min="2" max="1000" value="5">
+      <div class="control-group">
+        <div class="control-buttons">
+          <button type="button" class="icon-btn" id="sequence-start" title="Messreihe starten">
+            <span class="icon">{% include "icons/play.svg" %}</span>
+          </button>
+          <button type="button" class="icon-btn" id="sequence-stop" title="Messreihe stoppen">
+            <span class="icon">{% include "icons/stop.svg" %}</span>
+          </button>
+        </div>
+        <span id="sequence-duration"></span>
+      </div>
+      <div class="range-controls">
+        <div class="range-group">
+          <label for="sequence-interval">Intervall (s): <span id="sequence-interval-display">5</span></label>
+          <input type="range" id="sequence-interval" min="1" max="10" value="5">
+        </div>
+        <div class="range-group">
+          <label for="sequence-count">Anzahl: <span id="sequence-count-display">5</span></label>
+          <input type="range" id="sequence-count" min="2" max="1000" value="5">
+        </div>
       </div>
     </div>
   </section>

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -7,6 +7,7 @@
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  margin-bottom: 1rem;
 }
 .sequence-row,
 .measurement-main,
@@ -14,6 +15,17 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+.controls-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.control-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
 }
 .range-controls {
   display: flex;
@@ -27,6 +39,35 @@
 .range-group label,
 #sequence-duration {
   font-size: 0.45rem;
+}
+
+input[type=range] {
+  -webkit-appearance: none;
+  background: transparent;
+}
+input[type=range]::-webkit-slider-runnable-track {
+  height: 4px;
+  background: var(--secondary-700);
+}
+input[type=range]::-moz-range-track {
+  height: 4px;
+  background: var(--secondary-700);
+}
+input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 12px;
+  height: 12px;
+  background: var(--primary);
+  border: 1px solid var(--color-border);
+  border-radius: 0;
+  margin-top: -4px;
+}
+input[type=range]::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  background: var(--primary);
+  border: 1px solid var(--color-border);
+  border-radius: 0;
 }
 
 
@@ -55,6 +96,19 @@
 
 .measurement-table th {
   text-align: left;
+}
+
+.measurement-table th.measurement-column {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+}
+.measurement-table th.measurement-column input {
+  width: auto;
+  margin: 0;
+}
+.measurement-table th.measurement-column .icon-btn {
+  margin-left: 0.25rem;
 }
 
 .comment-toggle {

--- a/static/js/messung.js
+++ b/static/js/messung.js
@@ -181,6 +181,26 @@ document.addEventListener('DOMContentLoaded', () => {
       const laufnummer = Object.keys(sequences).length + 1;
       return `Messreihe ${laufnummer} (${date})`;
     }
+    function removeSequenceColumn(key) {
+      const idx = sequenceOrder.indexOf(key);
+      if (idx === -1) return;
+      const colIdx = 1 + idx * 2;
+      headerRow.removeChild(headerRow.children[colIdx]);
+      headerRow.removeChild(headerRow.children[colIdx]);
+      Array.from(tableBody.rows).forEach(row => {
+        row.removeChild(row.children[colIdx]);
+        row.removeChild(row.children[colIdx]);
+      });
+      sequences[key].option.remove();
+      delete sequences[key];
+      sequenceOrder.splice(idx, 1);
+      headerRow.querySelectorAll('.comment-toggle').forEach((btn, i) => {
+        btn.dataset.index = i;
+      });
+      activeSeqKey = sequenceOrder[sequenceOrder.length - 1] || null;
+      if (seqSelect) seqSelect.value = activeSeqKey || '';
+      markUnsaved();
+    }
 
       function addSequenceColumn(name) {
         const key = `seq${++seqCounter}`;
@@ -192,12 +212,29 @@ document.addEventListener('DOMContentLoaded', () => {
         input.type = 'text';
         input.value = name || autoSeqName();
         thVal.appendChild(input);
+        const delBtn = document.createElement('button');
+        delBtn.type = 'button';
+        delBtn.className = 'icon-btn delete-sequence';
+        delBtn.innerHTML = '<span class="icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="svg-icon" stroke="var(--svg-icon)" d="M14.7404 9L14.3942 18M9.60577 18L9.25962 9M19.2276 5.79057C19.5696 5.84221 19.9104 5.89747 20.25 5.95629M19.2276 5.79057L18.1598 19.6726C18.0696 20.8448 17.0921 21.75 15.9164 21.75H8.08357C6.90786 21.75 5.93037 20.8448 5.8402 19.6726L4.77235 5.79057M19.2276 5.79057C18.0812 5.61744 16.9215 5.48485 15.75 5.39432M3.75 5.95629C4.08957 5.89747 4.43037 5.84221 4.77235 5.79057M4.77235 5.79057C5.91878 5.61744 7.07849 5.48485 8.25 5.39432M15.75 5.39432V4.47819C15.75 3.29882 14.8393 2.31423 13.6606 2.27652C13.1092 2.25889 12.5556 2.25 12 2.25C11.4444 2.25 10.8908 2.25889 10.3394 2.27652C9.16065 2.31423 8.25 3.29882 8.25 4.47819V5.39432M15.75 5.39432C14.5126 5.2987 13.262 5.25 12 5.25C10.738 5.25 9.48744 5.2987 8.25 5.39432" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>';
+        delBtn.addEventListener('click', () => {
+          if (window.mmModal && window.mmModal.open) {
+            window.mmModal.open({
+              title: 'Messreihe löschen?',
+              text: 'Soll die Messreihe entfernt werden?',
+              okText: 'Löschen',
+              onConfirm: () => removeSequenceColumn(key)
+            });
+          } else {
+            removeSequenceColumn(key);
+          }
+        });
+        thVal.appendChild(delBtn);
         const cBtn = document.createElement('button');
         cBtn.type = 'button';
         cBtn.className = 'icon-btn comment-toggle';
         cBtn.dataset.index = measIdx;
         cBtn.innerHTML = eyeIcon;
-        cBtn.addEventListener('click', () => toggleCommentColumn(measIdx, cBtn));
+        cBtn.addEventListener('click', () => toggleCommentColumn(parseInt(cBtn.dataset.index, 10), cBtn));
         thVal.appendChild(cBtn);
         const deleteTh = headerRow.querySelector('.delete-column');
         headerRow.insertBefore(thVal, deleteTh);


### PR DESCRIPTION
## Summary
- Arrange measurement controls horizontally with duration beneath start/stop buttons
- Style range sliders to match theme and add square handles
- Allow deleting entire measurement series and adjust column to fit content

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a0dfab0b708323a8f0104f1f403fb1