### PR TITLE
Add spacer column to pin delete buttons and fix stats menu visibility

### DIFF
--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -80,11 +80,13 @@
     <table class="measurement-table">
       <colgroup id="measurement-colgroup">
         <col class="time-column">
+        <col class="filler-column">
         <col class="delete-column">
       </colgroup>
       <thead>
         <tr>
           <th class="time-column">Zeit</th>
+          <th class="filler-column"></th>
           <th class="delete-column"></th>
         </tr>
       </thead>
@@ -92,6 +94,8 @@
     </table>
   </section>
   <div id="sequence-overlay"><span id="sequence-countdown"></span></div>
+  {# Stats context menu #}
+  {% include "context_stats_menu.html" %}
 {% endblock %}
 {% block extra_js %}
   <script>

--- a/messung/templates/messung/projekte_page.html
+++ b/messung/templates/messung/projekte_page.html
@@ -74,23 +74,33 @@
   {% if selected_messung %}
     <section class="card">
       <table class="measurement-table">
+        <colgroup id="measurement-colgroup">
+          <col class="time-column">
+          {% for name in sequence_names %}
+            <col class="value-column">
+            <col class="comment-column" style="visibility: collapse;">
+          {% endfor %}
+        </colgroup>
         <thead>
           <tr>
             <th class="time-column">Zeit</th>
             {% for name in sequence_names %}
-              <th>{{ name }}</th>
-              <th>Kommentar</th>
+              <th class="measurement-column">
+                {{ name }}
+                <button type="button" class="icon-btn comment-toggle" data-index="{{ forloop.counter0 }}"></button>
+              </th>
+              <th class="comment-column" style="visibility: collapse;">Kommentar</th>
             {% endfor %}
           </tr>
         </thead>
-        <tbody>
+        <tbody id="measurement-table-body">
           {% if table_rows %}
             {% for row in table_rows %}
               <tr>
                 <td>{{ row.time }}</td>
                 {% for val in row.values %}
                   <td>{{ val.value }}</td>
-                  <td>{{ val.comment }}</td>
+                  <td class="comment-column" style="visibility: collapse;">{{ val.comment }}</td>
                 {% endfor %}
               </tr>
             {% endfor %}
@@ -101,6 +111,7 @@
       </table>
     </section>
   {% endif %}
+  {% include "context_stats_menu.html" %}
 {% endblock %}
 {% block extra_js %}
 {% if selected_projekt or selected_objekt or selected_messung %}
@@ -209,4 +220,5 @@
     });
   }
 </script>
+<script src="{% static 'js/projekte.js' %}"></script>
 {% endblock %}

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -124,8 +124,14 @@ input[type=range]::-moz-range-thumb {
   padding: 0.2rem;
 }
 
-.measurement-table td.delete-column {
-  text-align: center;
+/* Ensure delete buttons stay on the far right */
+.measurement-table .filler-column {
+  width: 100%;
+}
+.measurement-table .delete-column {
+  text-align: right;
+  width: 1%;
+  white-space: nowrap;
 }
 
 #sequence-overlay {
@@ -152,13 +158,15 @@ input[type=range]::-moz-range-thumb {
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
   z-index: 1000;
 }
-#column-context-menu ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
+#column-context-menu table {
+  border-collapse: collapse;
 }
-#column-context-menu li {
-  padding: 0.2rem 0;
+#column-context-menu th,
+#column-context-menu td {
+  padding: 0.2rem 0.5rem;
+}
+#column-context-menu th {
+  text-align: left;
 }
 
 .anforderung-modal {

--- a/static/js/projekte.js
+++ b/static/js/projekte.js
@@ -1,0 +1,98 @@
+// Table utilities for projects page
+
+document.addEventListener('DOMContentLoaded', () => {
+  const headerRow = document.querySelector('.measurement-table thead tr');
+  const tableBody = document.getElementById('measurement-table-body');
+  const colGroup = document.getElementById('measurement-colgroup');
+
+  if (!headerRow || !tableBody || !colGroup) return;
+
+  const nf2 = new Intl.NumberFormat('de-CH', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  const eyeIcon = '<span class="icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="svg-icon" stroke="var(--svg-icon)" d="M2.03555 12.3224C1.96647 12.1151 1.9664 11.8907 2.03536 11.6834C3.42372 7.50972 7.36079 4.5 12.0008 4.5C16.6387 4.5 20.5742 7.50692 21.9643 11.6776C22.0334 11.8849 22.0335 12.1093 21.9645 12.3166C20.5761 16.4903 16.6391 19.5 11.9991 19.5C7.36119 19.5 3.42564 16.4931 2.03555 12.3224Z"  stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path class="svg-icon" stroke="var(--svg-icon)" d="M15 12C15 13.6569 13.6569 15 12 15C10.3431 15 9 13.6569 9 12C9 10.3431 10.3431 9 12 9C13.6569 9 15 10.3431 15 12Z"  stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>';
+  const eyeSlashIcon = '<span class="icon"><svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path class="svg-icon" stroke="var(--svg-icon)" d="M3.97993 8.22257C3.05683 9.31382 2.35242 10.596 1.93436 12.0015C3.22565 16.338 7.24311 19.5 11.9991 19.5C12.9917 19.5 13.9521 19.3623 14.8623 19.1049M6.22763 6.22763C7.88389 5.13558 9.86771 4.5 12 4.5C16.756 4.5 20.7734 7.66205 22.0647 11.9985C21.3528 14.3919 19.8106 16.4277 17.772 17.772M6.22763 6.22763L3 3M6.22763 6.22763L9.87868 9.87868M17.772 17.772L21 21M17.772 17.772L14.1213 14.1213M14.1213 14.1213C14.6642 13.5784 15 12.8284 15 12C15 10.3431 13.6569 9 12 9C11.1716 9 10.4216 9.33579 9.87868 9.87868M14.1213 14.1213L9.87868 9.87868"  stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg></span>';
+
+  function toggleCommentColumn(idx, btn) {
+    const colIdx = 2 + idx * 2;
+    const th = headerRow.children[colIdx];
+    const col = colGroup.children[colIdx];
+    const hidden = th.style.visibility === 'collapse';
+    const vis = hidden ? 'visible' : 'collapse';
+    th.style.visibility = vis;
+    if (col) col.style.visibility = vis;
+    Array.from(tableBody.rows).forEach(row => {
+      if (row.children[colIdx]) row.children[colIdx].style.visibility = vis;
+    });
+    if (btn) btn.innerHTML = hidden ? eyeSlashIcon : eyeIcon;
+  }
+
+  headerRow.querySelectorAll('.comment-toggle').forEach(btn => {
+    btn.innerHTML = eyeIcon;
+    btn.addEventListener('click', () => toggleCommentColumn(parseInt(btn.dataset.index, 10), btn));
+  });
+
+  function computeArrayStats(values) {
+    if (!values.length) {
+      return { avg: null, min: null, max: null, u0: null };
+    }
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const sum = values.reduce((a, b) => a + b, 0);
+    const avg = sum / values.length;
+    const u0 = avg ? min / avg : null;
+    return { avg, min, max, u0 };
+  }
+
+  function getColumnValues(idx) {
+    return Array.from(tableBody.rows)
+      .map(row => {
+        const txt = row.children[idx]?.textContent;
+        return txt === '' ? null : parseFloat(txt);
+      })
+      .filter(v => v !== null && !isNaN(v));
+  }
+
+  function computeStatsFormatted(idx) {
+    const { avg, min, max, u0 } = computeArrayStats(getColumnValues(idx));
+    return {
+      avg: avg !== null ? nf2.format(avg) : '-',
+      min: min !== null ? nf2.format(min) : '-',
+      max: max !== null ? nf2.format(max) : '-',
+      u0: u0 !== null ? nf2.format(u0) : '-',
+    };
+  }
+
+  const columnMenu = document.getElementById('column-context-menu');
+  if (columnMenu) {
+    document.body.appendChild(columnMenu);
+    columnMenu.style.display = 'none';
+  }
+  const statsBody = columnMenu ? columnMenu.querySelector('tbody') : null;
+
+  document.addEventListener('click', () => {
+    if (columnMenu) columnMenu.style.display = 'none';
+  });
+
+  function updateStatsMenu() {
+    if (!statsBody) return;
+    const rows = Array.from(headerRow.querySelectorAll('.measurement-column'));
+    const html = rows.map((th, i) => {
+      const name = th.childNodes[0].textContent.trim();
+      const colIdx = 1 + i * 2;
+      const stats = computeStatsFormatted(colIdx);
+      return `<tr><td>${name}</td><td>${stats.avg}</td><td>${stats.min}</td><td>${stats.max}</td><td>${stats.u0}</td></tr>`;
+    }).join('');
+    statsBody.innerHTML = html;
+  }
+
+  if (headerRow && columnMenu) {
+    headerRow.addEventListener('contextmenu', e => {
+      const th = e.target.closest('th');
+      if (!th || !th.classList.contains('measurement-column')) return;
+      e.preventDefault();
+      updateStatsMenu();
+      columnMenu.style.left = `${e.pageX}px`;
+      columnMenu.style.top = `${e.pageY}px`;
+      columnMenu.style.display = 'block';
+    });
+  }
+});

--- a/templates/context_stats_menu.html
+++ b/templates/context_stats_menu.html
@@ -1,0 +1,14 @@
+<div id="column-context-menu">
+  <table>
+    <thead>
+      <tr>
+        <th>Messreihe</th>
+        <th>Em</th>
+        <th>Emin</th>
+        <th>Emax</th>
+        <th>U0</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</div>


### PR DESCRIPTION
## Summary
- keep delete column anchored to the far-right by inserting a flexible spacer column before it
- ensure shared stats menu attaches to body and stays hidden until invoked on measurement and project pages

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a100e12fec8323a754ce214726a869