### PR TITLE
Enable stats context menu when data present and fix delete column

### DIFF
--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -81,7 +81,7 @@
       <colgroup id="measurement-colgroup">
         <col class="time-column">
         <col class="filler-column">
-        <col class="delete-column">
+        <col class="delete-column" style="width:50px;">
       </colgroup>
       <thead>
         <tr>

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -130,7 +130,7 @@ input[type=range]::-moz-range-thumb {
 }
 .measurement-table .delete-column {
   text-align: right;
-  width: 1%;
+  width: 50px;
   white-space: nowrap;
 }
 

--- a/static/js/messung.js
+++ b/static/js/messung.js
@@ -127,6 +127,8 @@ document.addEventListener('DOMContentLoaded', () => {
       headerRow.addEventListener('contextmenu', e => {
         const th = e.target.closest('th');
         if (!th || !th.classList.contains('measurement-column')) return;
+        const colIdx = Array.from(headerRow.children).indexOf(th);
+        if (getColumnValues(colIdx).length === 0) return;
         e.preventDefault();
         updateStats();
         columnMenu.style.left = `${e.pageX}px`;

--- a/static/js/projekte.js
+++ b/static/js/projekte.js
@@ -88,6 +88,8 @@ document.addEventListener('DOMContentLoaded', () => {
     headerRow.addEventListener('contextmenu', e => {
       const th = e.target.closest('th');
       if (!th || !th.classList.contains('measurement-column')) return;
+      const colIdx = Array.from(headerRow.children).indexOf(th);
+      if (getColumnValues(colIdx).length === 0) return;
       e.preventDefault();
       updateStatsMenu();
       columnMenu.style.left = `${e.pageX}px`;


### PR DESCRIPTION
## Summary
- show stats context menu only when measurement columns contain values
- keep delete button column at fixed width on measurement table

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a11302610883239f42cd2f5690e82b