### PR TITLE
Remove duplicate home template and fix template path

### DIFF
--- a/mavomaster/settings.py
+++ b/mavomaster/settings.py
@@ -57,7 +57,7 @@ ROOT_URLCONF = 'mavomaster.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': ['templates'],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
## Summary
- remove empty `mavomaster/templates/home.html` to avoid conflicts
- ensure Django loads templates from the project `templates` directory by using an absolute path

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b704f734832381fb88dbb3bea3ca