### PR TITLE
Sidebar-Zustand einheitlich verwaltet

### DIFF
--- a/static/js/layout_footer.js
+++ b/static/js/layout_footer.js
@@ -3,15 +3,22 @@
 (function () {
   var STORAGE_KEY='mm.sidebar.collapsed';
 
-  function hasClass(e,c){return e&&(e.classList?e.classList.contains(c):new RegExp('(^|\\s)'+c+'(\\s|$)').test(e.className));}
-  function toggleClass(e,c){if(!e)return;if(e.classList)e.classList.toggle(c);else hasClass(e,c)?e.className=e.className.replace(new RegExp('(^|\\s)'+c+'(\\s|$)'),' ').trim():e.className+=(e.className?' ':'')+c;}
+  function setSidebarCollapsed(collapsed){
+    var method=collapsed?'add':'remove';
+    document.documentElement.classList[method]('sidebar-collapsed');
+    if(document.body)document.body.classList[method]('sidebar-collapsed');
+    try{localStorage.setItem(STORAGE_KEY,collapsed?'1':'0');}catch(e){}
+    var toggle=document.getElementById('sidebar-toggle');
+    if(toggle)toggle.setAttribute('aria-expanded',collapsed?'false':'true');
+  }
+
+  var collapsed=false;
+  try{collapsed=localStorage.getItem(STORAGE_KEY)==='1';}catch(e){}
+  setSidebarCollapsed(collapsed);
 
   var toggle=document.getElementById('sidebar-toggle');
   if(toggle){toggle.addEventListener('click',function(){
-    toggleClass(document.documentElement,'sidebar-collapsed');
-    toggleClass(document.body,'sidebar-collapsed');
-    try{localStorage.setItem(STORAGE_KEY,hasClass(document.documentElement,'sidebar-collapsed')?'1':'0');}catch(e){}
-    toggle.setAttribute('aria-expanded',hasClass(document.documentElement,'sidebar-collapsed')?'false':'true');
+    setSidebarCollapsed(!document.documentElement.classList.contains('sidebar-collapsed'));
   },{passive:true});}
 
   // Modal

--- a/static/js/layout_header.js
+++ b/static/js/layout_header.js
@@ -1,2 +1,0 @@
-// Hinweis: Keine Browser-Prompts zur Sicherstellung der mobilen Kompatibilität.
-(function(){try{if(localStorage.getItem('mm.sidebar.collapsed')==='1'){document.documentElement.classList.add('sidebar-collapsed');document.addEventListener('DOMContentLoaded',function(){document.body.classList.add('sidebar-collapsed');});}}catch(e){}})();

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}MavoMaster{% endblock %}</title>
-  <script src="{% static 'js/layout_header.js' %}"></script>
   <link rel="stylesheet" href="{% static 'css/style.css' %}">
   {% block extra_css %}{% endblock %}
 </head>


### PR DESCRIPTION
## Summary
- unify sidebar collapse handling in footer script
- drop obsolete layout_header.js and its template include

## Testing
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68a1b723df908323929757fe345a591d