### PR TITLE
Remove unused math import from measurement logic

### DIFF
--- a/messung/logic.py
+++ b/messung/logic.py
@@ -1,6 +1,5 @@
 import time
 import threading
-import math
 from channels.layers import get_channel_layer
 from asgiref.sync import async_to_sync
 import serial


### PR DESCRIPTION
## Summary
- remove unused math import from measurement logic module

## Testing
- `flake8 --select=F401`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a1b72ed63c8323b6d265bd09f08638