### PR TITLE
feat: always show column stats in context menu

### DIFF
--- a/static/js/messung.js
+++ b/static/js/messung.js
@@ -1,4 +1,4 @@
-import { toggleCommentColumn, computeArrayStats, getColumnValues, computeStatsFormatted, eyeIcon, eyeSlashIcon } from './table_utils.js';
+import { toggleCommentColumn, computeArrayStats, computeStatsFormatted, eyeIcon, eyeSlashIcon } from './table_utils.js';
 
 // Hinweis: Keine Browser-Prompts zur Sicherstellung der mobilen Kompatibilität.
 // page-specific scripts
@@ -84,8 +84,6 @@ document.addEventListener('DOMContentLoaded', () => {
       headerRow.addEventListener('contextmenu', e => {
         const th = e.target.closest('th');
         if (!th || !th.classList.contains('measurement-column')) return;
-        const colIdx = Array.from(headerRow.children).indexOf(th);
-        if (getColumnValues(tableBody, colIdx).length === 0) return;
         e.preventDefault();
         updateStats();
         columnMenu.style.left = `${e.pageX}px`;

--- a/static/js/projekte.js
+++ b/static/js/projekte.js
@@ -1,4 +1,4 @@
-import { toggleCommentColumn, getColumnValues, computeStatsFormatted, eyeIcon, eyeSlashIcon } from './table_utils.js';
+import { toggleCommentColumn, computeStatsFormatted, eyeIcon, eyeSlashIcon } from './table_utils.js';
 
 // Table utilities for projects page
 
@@ -47,8 +47,6 @@ document.addEventListener('DOMContentLoaded', () => {
     headerRow.addEventListener('contextmenu', e => {
       const th = e.target.closest('th');
       if (!th || !th.classList.contains('measurement-column')) return;
-      const colIdx = Array.from(headerRow.children).indexOf(th);
-      if (getColumnValues(tableBody, colIdx).length === 0) return;
       e.preventDefault();
       updateStatsMenu();
       columnMenu.style.left = `${e.pageX}px`;


### PR DESCRIPTION
## Summary
- always display column stats in context menu, even without data
- remove unused `getColumnValues` imports

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a1c2da350c8323822737406c69db73