### PR TITLE
feat: show stats in sidebar

### DIFF
--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -33,6 +33,10 @@
   </form>
   {% if selected_messung %}
     {% include "messung/messung_edit.html" %}
+    <div class="card" id="sidebar-stats">
+      <h3>Statuswerte</h3>
+      {% include "stats_table.html" %}
+    </div>
   {% endif %}
 {% endblock %}
 {% block content %}

--- a/messung/templates/messung/projekte_page.html
+++ b/messung/templates/messung/projekte_page.html
@@ -9,6 +9,12 @@
   {% if selected_projekt %}
     {% include "messung/objekt_edit.html" %}
   {% endif %}
+  {% if selected_messung %}
+    <div class="card" id="sidebar-stats">
+      <h3>Statuswerte</h3>
+      {% include "stats_table.html" %}
+    </div>
+  {% endif %}
 {% endblock %}
 {% block content %}
   <div class="element-columns">

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -171,6 +171,17 @@ input[type=range]::-moz-range-thumb {
   text-align: left;
 }
 
+#sidebar-stats table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+#sidebar-stats th,
+#sidebar-stats td {
+  padding: 0.2rem 0.5rem;
+  text-align: left;
+}
+
 .anforderung-modal {
   position: fixed;
   top: 0;

--- a/static/js/projekte.js
+++ b/static/js/projekte.js
@@ -23,14 +23,14 @@ document.addEventListener('DOMContentLoaded', () => {
     document.body.appendChild(columnMenu);
     columnMenu.style.display = 'none';
   }
-  const statsBody = columnMenu ? columnMenu.querySelector('tbody') : null;
+  const menuStatsBody = columnMenu ? columnMenu.querySelector('tbody') : null;
+  const sidebarStatsBody = document.querySelector('#sidebar-stats tbody');
 
   document.addEventListener('click', e => {
     if (e.button !== 2 && columnMenu) columnMenu.style.display = 'none';
   });
 
-  function updateStatsMenu() {
-    if (!statsBody) return;
+  function renderStats() {
     const rows = Array.from(headerRow.querySelectorAll('.measurement-column'));
     const html = rows
       .map((th, i) => {
@@ -40,18 +40,25 @@ document.addEventListener('DOMContentLoaded', () => {
         return `<tr><td>${name}</td><td>${stats.avg}</td><td>${stats.min}</td><td>${stats.max}</td><td>${stats.u0}</td></tr>`;
       })
       .join('');
-    statsBody.innerHTML = html;
+    if (menuStatsBody) menuStatsBody.innerHTML = html;
+    if (sidebarStatsBody) sidebarStatsBody.innerHTML = html;
   }
 
-  if (headerRow && columnMenu) {
-    headerRow.addEventListener('contextmenu', e => {
-      const th = e.target.closest('th');
-      if (!th || !th.classList.contains('measurement-column')) return;
-      e.preventDefault();
-      updateStatsMenu();
-      columnMenu.style.left = `${e.pageX}px`;
-      columnMenu.style.top = `${e.pageY}px`;
-      columnMenu.style.display = 'block';
-    });
+  if (headerRow) {
+    if (columnMenu) {
+      headerRow.addEventListener('contextmenu', e => {
+        const th = e.target.closest('th');
+        if (!th || !th.classList.contains('measurement-column')) return;
+        e.preventDefault();
+        renderStats();
+        columnMenu.style.left = `${e.pageX}px`;
+        columnMenu.style.top = `${e.pageY}px`;
+        columnMenu.style.display = 'block';
+      });
+    }
+    if (sidebarStatsBody) {
+      renderStats();
+      setInterval(renderStats, 500);
+    }
   }
 });

--- a/templates/context_stats_menu.html
+++ b/templates/context_stats_menu.html
@@ -1,14 +1,3 @@
 <div id="column-context-menu">
-  <table>
-    <thead>
-      <tr>
-        <th>Messreihe</th>
-        <th>Em</th>
-        <th>Emin</th>
-        <th>Emax</th>
-        <th>U0</th>
-      </tr>
-    </thead>
-    <tbody></tbody>
-  </table>
+  {% include "stats_table.html" %}
 </div>

--- a/templates/stats_table.html
+++ b/templates/stats_table.html
@@ -1,0 +1,12 @@
+<table>
+  <thead>
+    <tr>
+      <th>Messreihe</th>
+      <th>Em</th>
+      <th>Emin</th>
+      <th>Emax</th>
+      <th>U0</th>
+    </tr>
+  </thead>
+  <tbody></tbody>
+</table>


### PR DESCRIPTION
## Summary
- display measurement stats in sidebar on measurement and project pages
- refactor stat table as reusable template and update JS to refresh values

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a1d18695ec8323b63bcd1132d79328