### PR TITLE
Style requirements popup like existing modals

### DIFF
--- a/messung/templates/messung/messung_edit.html
+++ b/messung/templates/messung/messung_edit.html
@@ -46,10 +46,14 @@
   </div>
 </form>
 
-<div id="anforderung-modal" class="anforderung-modal">
-  <div class="modal-content">
+<div id="anforderung-modal" class="mm-modal" aria-hidden="true">
+  <div class="mm-modal__backdrop" data-mm-close></div>
+  <div class="mm-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="anforderung-modal-title">
+    <h3 id="anforderung-modal-title" class="mm-modal__title">Anforderungen</h3>
     <input type="text" id="anforderung-search" placeholder="Suche...">
     <div id="anforderung-results"></div>
-    <button type="button" id="anforderung-close" class="icon-btn">Schließen</button>
+    <div class="mm-modal__actions">
+      <button type="button" id="anforderung-close" class="mm-btn mm-btn--primary" data-mm-close>Schließen</button>
+    </div>
   </div>
 </div>

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -182,26 +182,18 @@ input[type=range]::-moz-range-thumb {
   text-align: left;
 }
 
-.anforderung-modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.3);
-  z-index: 1500;
-}
-
-.anforderung-modal .modal-content {
-  background: var(--color-bg, #fff);
-  padding: 1rem;
+#anforderung-modal .mm-modal__dialog {
   max-height: 80vh;
-  overflow: auto;
   width: 80%;
   max-width: 400px;
+  display: flex;
+  flex-direction: column;
+}
+
+#anforderung-results {
+  flex: 1;
+  overflow: auto;
+  margin-top: 0.5rem;
 }
 
 #anforderung-results .bereich {

--- a/static/js/messung.js
+++ b/static/js/messung.js
@@ -509,36 +509,41 @@ document.addEventListener('DOMContentLoaded', () => {
             const li = document.createElement('li');
             const label = [a.ref, a.typ].filter(Boolean).join(' ');
             li.textContent = label;
-            li.addEventListener('click', () => {
-              if (anforderungInput) anforderungInput.value = a.id;
-              if (anforderungDisplay) anforderungDisplay.textContent = label;
-              anforderungModal.style.display = 'none';
-              markUnsaved();
-            });
+              li.addEventListener('click', () => {
+                if (anforderungInput) anforderungInput.value = a.id;
+                if (anforderungDisplay) anforderungDisplay.textContent = label;
+                closeAnforderungModal();
+                markUnsaved();
+              });
             ul.appendChild(li);
           });
           anforderungResults.appendChild(ul);
         });
       }
 
+      const openAnforderungModal = () => {
+        renderAnforderungen(window.anforderungenData || []);
+        anforderungModal.setAttribute('aria-hidden', 'false');
+        if (anforderungSearch) {
+          anforderungSearch.value = '';
+          anforderungSearch.focus();
+        }
+      };
+      const closeAnforderungModal = () => {
+        anforderungModal.setAttribute('aria-hidden', 'true');
+      };
+
       if (anforderungBtn && anforderungModal) {
-        anforderungBtn.addEventListener('click', () => {
-          renderAnforderungen(window.anforderungenData || []);
-          anforderungModal.style.display = 'flex';
-          if (anforderungSearch) {
-            anforderungSearch.value = '';
-            anforderungSearch.focus();
-          }
-        });
+        anforderungBtn.addEventListener('click', openAnforderungModal);
       }
       if (anforderungClose) {
-        anforderungClose.addEventListener('click', () => {
-          anforderungModal.style.display = 'none';
-        });
+        anforderungClose.addEventListener('click', closeAnforderungModal);
       }
       if (anforderungModal) {
         anforderungModal.addEventListener('click', e => {
-          if (e.target === anforderungModal) anforderungModal.style.display = 'none';
+          if (e.target && e.target.hasAttribute('data-mm-close')) {
+            closeAnforderungModal();
+          }
         });
       }
       if (anforderungSearch) {


### PR DESCRIPTION
## Summary
- restyle the requirements selection popup to use the global modal design
- ensure popup contents scroll and include dedicated close actions
- simplify JS by reusing aria-hidden and data-mm-close attributes

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a1d82cd1f08323a53c4edc01749eff