### PR TITLE
Show requirement values and stripe measurement table

### DIFF
--- a/messung/templates/messung/messung_edit.html
+++ b/messung/templates/messung/messung_edit.html
@@ -33,7 +33,12 @@
       </button>
       <span id="anforderung-display">
         {% if selected_messung and selected_messung.anforderung %}
-          {{ selected_messung.anforderung.ref }}{% if selected_messung.anforderung.typ %} {{ selected_messung.anforderung.typ }}{% endif %}
+          {% with a=selected_messung.anforderung %}
+            {{ a.ref }}{% if a.typ %} {{ a.typ }}{% endif %}{% if a.avg or a.avgmod or a.u0 %} (
+            {% if a.avg %}{{ a.avg|floatformat:2 }}{% endif %}
+            {% if a.avgmod %}{% if a.avg %} / {% endif %}{{ a.avgmod|floatformat:2 }}{% endif %}
+            {% if a.u0 %}{% if a.avg or a.avgmod %} / {% endif %}{{ a.u0|floatformat:2 }}{% endif %}){% endif %}
+          {% endwith %}
         {% else %}–{% endif %}
       </span>
     </div>

--- a/messung/templates/messung/messung_page.html
+++ b/messung/templates/messung/messung_page.html
@@ -91,6 +91,7 @@
   <script>
     window.initialTable = {{ initial_table|safe }};
     window.anforderungenData = {{ anforderungen_json|safe }};
+    window.anforderungStats = {{ anforderung_stats|safe }};
   </script>
   <script src="{% static 'js/NoSleep.min.js' %}"></script>
   <script type="module" src="{% static 'js/messung.js' %}"></script>

--- a/messung/templates/messung/projekte_page.html
+++ b/messung/templates/messung/projekte_page.html
@@ -191,5 +191,8 @@
     });
   }
 </script>
+<script>
+  window.anforderungStats = {{ anforderung_stats|safe }};
+</script>
 <script type="module" src="{% static 'js/projekte.js' %}"></script>
 {% endblock %}

--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -99,6 +99,14 @@ input[type=range]::-moz-range-thumb {
   border-bottom: 1px solid var(--color-border);
 }
 
+.measurement-table tbody tr:nth-child(odd) {
+  background: var(--color-surface);
+}
+
+.measurement-table tbody tr:nth-child(even) {
+  background: var(--color-background);
+}
+
 .measurement-table th.time-column,
 .measurement-table td.time-column {
   width: 6rem;

--- a/static/js/messung.js
+++ b/static/js/messung.js
@@ -68,7 +68,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderStats = () => {
       if (!headerRow) return;
       const cols = Array.from(headerRow.querySelectorAll('.measurement-column'));
-      const html = cols
+      const fmt = v => (v !== null && v !== undefined ? nf2.format(v) : '-');
+      const seqRows = cols
         .map(th => {
           const nameInput = th.querySelector('input');
           const name = nameInput ? nameInput.value : th.textContent.trim();
@@ -77,6 +78,10 @@ document.addEventListener('DOMContentLoaded', () => {
           return `<tr><td>${name}</td><td>${stats.avg}</td><td>${stats.min}</td><td>${stats.max}</td><td>${stats.u0}</td></tr>`;
         })
         .join('');
+      const baseRow = window.anforderungStats
+        ? `<tr><td>Vorgabe</td><td>${fmt(window.anforderungStats.avg)}</td><td>${fmt(window.anforderungStats.emin)}</td><td>${fmt(window.anforderungStats.emax)}</td><td>${fmt(window.anforderungStats.u0)}</td></tr>`
+        : '';
+      const html = baseRow + seqRows;
       if (menuStatsBody) menuStatsBody.innerHTML = html;
       if (sidebarStatsBody) sidebarStatsBody.innerHTML = html;
     };
@@ -516,6 +521,7 @@ document.addEventListener('DOMContentLoaded', () => {
           (grouped[b] = grouped[b] || []).push(a);
         });
         anforderungResults.innerHTML = '';
+        const fmt = v => (v !== null && v !== undefined ? nf2.format(v) : null);
         Object.keys(grouped).sort().forEach(b => {
           const bDiv = document.createElement('div');
           bDiv.className = 'bereich';
@@ -526,13 +532,15 @@ document.addEventListener('DOMContentLoaded', () => {
           grouped[b].forEach(a => {
             const li = document.createElement('li');
             const label = [a.ref, a.typ].filter(Boolean).join(' ');
-            li.textContent = label;
-              li.addEventListener('click', () => {
-                if (anforderungInput) anforderungInput.value = a.id;
-                if (anforderungDisplay) anforderungDisplay.textContent = label;
-                closeAnforderungModal();
-                markUnsaved();
-              });
+            const values = [fmt(a.avg), fmt(a.avgmod), fmt(a.u0)].filter(Boolean).join(' / ');
+            const text = values ? `${label} (${values})` : label;
+            li.textContent = text;
+            li.addEventListener('click', () => {
+              if (anforderungInput) anforderungInput.value = a.id;
+              if (anforderungDisplay) anforderungDisplay.textContent = text;
+              closeAnforderungModal();
+              markUnsaved();
+            });
             ul.appendChild(li);
           });
           anforderungResults.appendChild(ul);

--- a/static/js/projekte.js
+++ b/static/js/projekte.js
@@ -1,5 +1,9 @@
 import { toggleCommentColumn, computeStatsFormatted, eyeIcon, eyeSlashIcon } from './table_utils.js';
 
+function numberIcon(num) {
+  return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/><text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">${num}</text></svg>`;
+}
+
 // Table utilities for projects page
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -18,7 +22,8 @@ document.addEventListener('DOMContentLoaded', () => {
     );
   });
 
-  headerRow.querySelectorAll('.title-toggle').forEach(btn => {
+  headerRow.querySelectorAll('.title-toggle').forEach((btn, idx) => {
+    btn.innerHTML = numberIcon(idx + 1);
     btn.addEventListener('click', () => {
       const title = btn.parentElement.querySelector('.seq-title');
       if (title) title.classList.toggle('hidden');
@@ -39,7 +44,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function renderStats() {
     const rows = Array.from(headerRow.querySelectorAll('.measurement-column'));
-    const html = rows
+    const fmt = v => (v !== null && v !== undefined ? nf2.format(v) : '-');
+    const seqRows = rows
       .map((th, i) => {
         const name = th.querySelector('.seq-title') ? th.querySelector('.seq-title').textContent.trim() : th.textContent.trim();
         const colIdx = 2 + i * 2;
@@ -47,6 +53,10 @@ document.addEventListener('DOMContentLoaded', () => {
         return `<tr><td>${name}</td><td>${stats.avg}</td><td>${stats.min}</td><td>${stats.max}</td><td>${stats.u0}</td></tr>`;
       })
       .join('');
+    const baseRow = window.anforderungStats
+      ? `<tr><td>Vorgabe</td><td>${fmt(window.anforderungStats.avg)}</td><td>${fmt(window.anforderungStats.emin)}</td><td>${fmt(window.anforderungStats.emax)}</td><td>${fmt(window.anforderungStats.u0)}</td></tr>`
+      : '';
+    const html = baseRow + seqRows;
     if (menuStatsBody) menuStatsBody.innerHTML = html;
     if (sidebarStatsBody) sidebarStatsBody.innerHTML = html;
   }


### PR DESCRIPTION
## Summary
- display requirement metrics in the selection popup and selected field
- show requirement defaults in sidebar status stats
- fix missing circle icons on project measurement table and add row banding

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a1f2b827bc832384d9e99cf835a58d