### PR TITLE
Replace visibility collapse with display none

### DIFF
--- a/templates/measurement_table.html
+++ b/templates/measurement_table.html
@@ -6,7 +6,7 @@
       {% for name in sequence_names %}
         <col class="value-column">
         {% if show_comments %}
-          <col class="comment-column" style="visibility: collapse;">
+          <col class="comment-column" style="display: none;">
         {% endif %}
       {% endfor %}
     {% endif %}
@@ -32,7 +32,7 @@
             {% endif %}
           </th>
           {% if show_comments %}
-            <th class="comment-column" style="visibility: collapse;">Kommentar</th>
+            <th class="comment-column" style="display: none;">Kommentar</th>
           {% endif %}
         {% endfor %}
       {% endif %}
@@ -48,7 +48,7 @@
           {% for val in row.values %}
             <td>{{ val.value }}</td>
             {% if show_comments %}
-              <td class="comment-column" style="visibility: collapse;">{{ val.comment }}</td>
+              <td class="comment-column" style="display: none;">{{ val.comment }}</td>
             {% endif %}
           {% endfor %}
           <td class="filler-cell"></td>


### PR DESCRIPTION
## Summary
- use `display: none` for comment columns in `measurement_table` instead of `visibility: collapse`

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a22d3679f883239bd11d39b41def9f