### PR TITLE
Replace visibility collapse with display none

### DIFF
--- a/static/js/messung.js
+++ b/static/js/messung.js
@@ -211,7 +211,7 @@ document.addEventListener('DOMContentLoaded', () => {
         colGroup.insertBefore(valCol, fillerCol);
         const commentCol = document.createElement('col');
         commentCol.className = 'comment-column';
-        commentCol.style.visibility = 'collapse';
+        commentCol.style.display = 'none';
         colGroup.insertBefore(commentCol, fillerCol);
 
         const thVal = document.createElement('th');
@@ -261,14 +261,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const thComment = document.createElement('th');
         thComment.classList.add('comment-column');
         thComment.textContent = 'Kommentar';
-        thComment.style.visibility = 'collapse';
+        thComment.style.display = 'none';
         headerRow.insertBefore(thComment, fillerTh);
         Array.from(tableBody.rows).forEach(row => {
           const fillerCell = row.querySelector('.filler-cell');
           const valTd = document.createElement('td');
           row.insertBefore(valTd, fillerCell);
           const cTd = document.createElement('td');
-          cTd.style.visibility = 'collapse';
+          cTd.style.display = 'none';
           const cInput = document.createElement('input');
           cInput.type = 'text';
           cInput.addEventListener('input', markUnsaved);
@@ -318,7 +318,7 @@ document.addEventListener('DOMContentLoaded', () => {
           const valTd = document.createElement('td');
           row.appendChild(valTd);
           const cTd = document.createElement('td');
-          cTd.style.visibility = headerRow.children[3 + idx * 2]?.style.visibility || 'collapse';
+          cTd.style.display = headerRow.children[3 + idx * 2]?.style.display || 'none';
           const cInput = document.createElement('input');
           cInput.type = 'text';
           cInput.addEventListener('input', markUnsaved);
@@ -335,8 +335,8 @@ document.addEventListener('DOMContentLoaded', () => {
           row.children[3 + orderIdx * 2].querySelector('input').value = comment;
         }
       Array.from(headerRow.children).forEach((th, idx) => {
-        if (th.style.visibility === 'collapse' && row.children[idx]) {
-          row.children[idx].style.visibility = 'collapse';
+        if (th.style.display === 'none' && row.children[idx]) {
+          row.children[idx].style.display = 'none';
         }
       });
       markUnsaved();

--- a/static/js/table_utils.js
+++ b/static/js/table_utils.js
@@ -5,12 +5,12 @@ export function toggleCommentColumn(headerRow, tableBody, colGroup, idx, btn, ey
   const colIdx = 3 + idx * 2;
   const th = headerRow.children[colIdx];
   const col = colGroup.children[colIdx];
-  const hidden = th.style.visibility === 'collapse';
-  const vis = hidden ? 'visible' : 'collapse';
-  th.style.visibility = vis;
-  if (col) col.style.visibility = vis;
+  const hidden = th.style.display === 'none';
+  const disp = hidden ? '' : 'none';
+  th.style.display = disp;
+  if (col) col.style.display = disp;
   Array.from(tableBody.rows).forEach(row => {
-    if (row.children[colIdx]) row.children[colIdx].style.visibility = vis;
+    if (row.children[colIdx]) row.children[colIdx].style.display = disp;
   });
   if (btn) btn.innerHTML = hidden ? eyeSlashIcon : eyeIcon;
 }

--- a/templates/measurement_table.html
+++ b/templates/measurement_table.html
@@ -6,7 +6,7 @@
       {% for name in sequence_names %}
         <col class="value-column">
         {% if show_comments %}
-          <col class="comment-column" style="visibility: collapse;">
+          <col class="comment-column" style="display: none;">
         {% endif %}
       {% endfor %}
     {% endif %}
@@ -32,7 +32,7 @@
             {% endif %}
           </th>
           {% if show_comments %}
-            <th class="comment-column" style="visibility: collapse;">Kommentar</th>
+            <th class="comment-column" style="display: none;">Kommentar</th>
           {% endif %}
         {% endfor %}
       {% endif %}
@@ -48,7 +48,7 @@
           {% for val in row.values %}
             <td>{{ val.value }}</td>
             {% if show_comments %}
-              <td class="comment-column" style="visibility: collapse;">{{ val.comment }}</td>
+              <td class="comment-column" style="display: none;">{{ val.comment }}</td>
             {% endif %}
           {% endfor %}
           <td class="filler-cell"></td>


### PR DESCRIPTION
## Summary
- use `display: none` for comment columns in `measurement_table` instead of `visibility: collapse`
- update toggle logic to switch comment columns by updating their `display` style

## Testing
- `node --input-type=module` script exercising `toggleCommentColumn`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68a22d3679f883239bd11d39b41def9f