### PR TITLE
Style tables with zebra striping and fixed headers

### DIFF
--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -96,7 +96,15 @@ input[type=range]::-moz-range-thumb {
 .measurement-table th,
 .measurement-table td {
   padding: 0.5rem;
-  border-bottom: 1px solid var(--color-border);
+  border: none;
+}
+
+.measurement-table tbody tr:nth-child(odd) {
+  background-color: var(--color-surface);
+}
+
+.measurement-table tbody tr:nth-child(even) {
+  background-color: var(--color-background);
 }
 
 .measurement-table th.time-column,
@@ -107,6 +115,11 @@ input[type=range]::-moz-range-thumb {
 
 .measurement-table th {
   text-align: left;
+  white-space: nowrap;
+}
+
+.measurement-table th .seq-title {
+  white-space: nowrap;
 }
 
 .measurement-table th.measurement-column {
@@ -166,26 +179,29 @@ input[type=range]::-moz-range-thumb {
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
   z-index: 1000;
 }
-#column-context-menu table {
-  border-collapse: collapse;
-}
-#column-context-menu th,
-#column-context-menu td {
-  padding: 0.2rem 0.5rem;
-}
-#column-context-menu th {
-  text-align: left;
-}
 
-#sidebar-stats table {
+.stats-table {
   width: 100%;
   border-collapse: collapse;
 }
 
-#sidebar-stats th,
-#sidebar-stats td {
+.stats-table th,
+.stats-table td {
   padding: 0.2rem 0.5rem;
   text-align: left;
+  border: none;
+}
+
+.stats-table th {
+  white-space: nowrap;
+}
+
+.stats-table tbody tr:nth-child(odd) {
+  background-color: var(--color-surface);
+}
+
+.stats-table tbody tr:nth-child(even) {
+  background-color: var(--color-background);
 }
 
 #anforderung-modal .mm-modal__dialog {

--- a/templates/stats_table.html
+++ b/templates/stats_table.html
@@ -1,4 +1,4 @@
-<table>
+<table class="stats-table">
   <thead>
     <tr>
       <th>Messreihe</th>


### PR DESCRIPTION
## Summary
- zebra stripe measurement and stats tables
- remove table row borders
- keep table headers on a single line

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a235c442a08323a63c0239f043abed