### PR TITLE
Fix header layout without comments and restore circle number icons

### DIFF
--- a/static/css/messung.css
+++ b/static/css/messung.css
@@ -123,7 +123,8 @@ input[type=range]::-moz-range-thumb {
 }
 
 .measurement-table th.measurement-column {
-  display: flex;
+  display: inline-flex;
+  flex-direction: row;
   align-items: center;
   white-space: nowrap;
 }

--- a/templates/icons/circle-number-0.svg
+++ b/templates/icons/circle-number-0.svg
@@ -1,19 +1,4 @@
-<!--
-tags: [zero, number, digit, quantity, amount, order, maths, sum, total]
-category: Numbers
-version: "1.39"
-unicode: "ee34"
--->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke-width="1.5"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M10 10v4a2 2 0 1 0 4 0v-4a2 2 0 1 0 -4 0z" />
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/>
+  <text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">0</text>
 </svg>

--- a/templates/icons/circle-number-1.svg
+++ b/templates/icons/circle-number-1.svg
@@ -1,26 +1,4 @@
-<<<<<<< HEAD
-<!--
-tags: [one, zero, number, digit, quantity, amount, order, maths, sum, total]
-category: Numbers
-version: "1.39"
-unicode: "ee35"
--->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke="currentColor"
-  stroke-width="1.5"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M10 10l2 -2v8" />
-=======
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/>
   <text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">1</text>
->>>>>>> 47cdfb14280abce9411abb04cbe0d456e3923f07
 </svg>

--- a/templates/icons/circle-number-2.svg
+++ b/templates/icons/circle-number-2.svg
@@ -1,25 +1,4 @@
-<<<<<<< HEAD
-<!--
-tags: [two, zero, number, digit, quantity, amount, order, maths, sum, total]
-category: Numbers
-version: "1.39"
-unicode: "ee36"
--->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke-width="1.5"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M10 8h3a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-2a1 1 0 0 0 -1 1v2a1 1 0 0 0 1 1h3" />
-=======
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/>
   <text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">2</text>
->>>>>>> 47cdfb14280abce9411abb04cbe0d456e3923f07
 </svg>

--- a/templates/icons/circle-number-3.svg
+++ b/templates/icons/circle-number-3.svg
@@ -1,25 +1,4 @@
-<<<<<<< HEAD
-<!--
-tags: [three, zero, number, digit, quantity, amount, order, maths, sum, total]
-category: Numbers
-version: "1.39"
-unicode: "ee37"
--->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke-width="1.5"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M10 9a1 1 0 0 1 1 -1h2a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-2h2a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-2a1 1 0 0 1 -1 -1" />
-=======
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/>
   <text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">3</text>
->>>>>>> 47cdfb14280abce9411abb04cbe0d456e3923f07
 </svg>

--- a/templates/icons/circle-number-4.svg
+++ b/templates/icons/circle-number-4.svg
@@ -1,26 +1,4 @@
-<<<<<<< HEAD
-<!--
-tags: [four, zero, number, digit, quantity, amount, order, maths, sum, total]
-category: Numbers
-version: "1.39"
-unicode: "ee38"
--->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke-width="1.5"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M10 8v3a1 1 0 0 0 1 1h3" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M14 8v8" />
-=======
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/>
   <text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">4</text>
->>>>>>> 47cdfb14280abce9411abb04cbe0d456e3923f07
 </svg>

--- a/templates/icons/circle-number-5.svg
+++ b/templates/icons/circle-number-5.svg
@@ -1,25 +1,4 @@
-<<<<<<< HEAD
-<!--
-tags: [five, zero, number, digit, quantity, amount, order, maths, sum, total]
-category: Numbers
-version: "1.39"
-unicode: "ee39"
--->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke-width="1.5"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M10 15a1 1 0 0 0 1 1h2a1 1 0 0 0 1 -1v-2a1 1 0 0 0 -1 -1h-3v-4h4" />
-=======
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/>
   <text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">5</text>
->>>>>>> 47cdfb14280abce9411abb04cbe0d456e3923f07
 </svg>

--- a/templates/icons/circle-number-6.svg
+++ b/templates/icons/circle-number-6.svg
@@ -1,25 +1,4 @@
-<<<<<<< HEAD
-<!--
-tags: [six, zero, number, digit, quantity, amount, order, maths, sum, total]
-category: Numbers
-version: "1.39"
-unicode: "ee3a"
--->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke-width="1.5"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M14 9a1 1 0 0 0 -1 -1h-2a1 1 0 0 0 -1 1v6a1 1 0 0 0 1 1h2a1 1 0 0 0 1 -1v-2a1 1 0 0 0 -1 -1h-3" />
-=======
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/>
   <text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">6</text>
->>>>>>> 47cdfb14280abce9411abb04cbe0d456e3923f07
 </svg>

--- a/templates/icons/circle-number-7.svg
+++ b/templates/icons/circle-number-7.svg
@@ -1,25 +1,4 @@
-<<<<<<< HEAD
-<!--
-tags: [seven, zero, number, digit, quantity, amount, order, maths, sum, total]
-category: Numbers
-version: "1.39"
-unicode: "ee3b"
--->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke-width="1.5"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M10 8h4l-2 8" />
-=======
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/>
   <text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">7</text>
->>>>>>> 47cdfb14280abce9411abb04cbe0d456e3923f07
 </svg>

--- a/templates/icons/circle-number-8.svg
+++ b/templates/icons/circle-number-8.svg
@@ -1,25 +1,4 @@
-<<<<<<< HEAD
-<!--
-tags: [eight, zero, number, digit, quantity, amount, order, maths, sum, total]
-category: Numbers
-version: "1.39"
-unicode: "ee3c"
--->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke-width="1.5"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12h-1a1 1 0 0 1 -1 -1v-2a1 1 0 0 1 1 -1h2a1 1 0 0 1 1 1v2a1 1 0 0 1 -1 1h-2a1 1 0 0 0 -1 1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1 -1v-2a1 1 0 0 0 -1 -1" />
-=======
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/>
   <text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">8</text>
->>>>>>> 47cdfb14280abce9411abb04cbe0d456e3923f07
 </svg>

--- a/templates/icons/circle-number-9.svg
+++ b/templates/icons/circle-number-9.svg
@@ -1,25 +1,4 @@
-<<<<<<< HEAD
-<!--
-tags: [nine, zero, number, digit, quantity, amount, order, maths, sum, total]
-category: Numbers
-version: "1.39"
-unicode: "ee3d"
--->
-<svg
-  xmlns="http://www.w3.org/2000/svg"
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  stroke-width="1.5"
-  stroke-linecap="round"
-  stroke-linejoin="round"
->
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M12 12m-9 0a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
-  <path class="svg-icon" stroke="var(--svg-icon)" d="M10 15a1 1 0 0 0 1 1h2a1 1 0 0 0 1 -1v-6a1 1 0 0 0 -1 -1h-2a1 1 0 0 0 -1 1v2a1 1 0 0 0 1 1h3" />
-=======
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
   <circle class="svg-icon" stroke="var(--svg-icon)" stroke-width="1.5" cx="12" cy="12" r="9"/>
   <text x="12" y="16" text-anchor="middle" font-size="12" fill="var(--svg-icon)" font-family="sans-serif">9</text>
->>>>>>> 47cdfb14280abce9411abb04cbe0d456e3923f07
 </svg>


### PR DESCRIPTION
## Summary
- keep measurement table headers horizontal when comment columns are hidden
- replace corrupted circle-number SVGs so sequence buttons show numbers again

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a24438f26c8323b1ee376642d5cbf3